### PR TITLE
Command registry class

### DIFF
--- a/src/planning_permission/tests/utils/test_command_registry.py
+++ b/src/planning_permission/tests/utils/test_command_registry.py
@@ -1,0 +1,104 @@
+import unittest
+from planning_permission.utils.command_registry import CommandRegistry
+import unittest
+
+class TestCommandRegistry(unittest.TestCase):
+    def test_default_command(self):
+        registry = CommandRegistry()
+        registry.set_default_command(lambda input: f"Default command: {input}")
+        
+        @registry.command('existing_command')
+        def existing_command() -> str:
+            return "This is a existing command."
+        
+        self.assertEqual(registry.execute('Test'), "Default command: Test")
+
+    def test_simple_command(self):
+        registry = CommandRegistry()
+        
+        @registry.command('simple_command')
+        def simple_command() -> str:
+            return "This is a simple command."
+
+        registry.set_default_command(lambda input: f"Default command: {input}")
+        self.assertEqual(registry.execute('/simple_command'), "This is a simple command.")
+
+    def test_command_with_one_arg(self):
+        registry = CommandRegistry()
+
+        @registry.command('command_with_one_arg')
+        def command_with_one_arg(arg: str) -> str:
+            return f"Arg: {arg}"
+
+        self.assertEqual(registry.execute('/command_with_one_arg lol'), "Arg: lol")
+
+    def test_command_with_many_args(self):
+        registry = CommandRegistry()
+
+        @registry.command('command_with_many_args')
+        def command_with_many_args(arg1: int, arg2: int, arg3: int) -> str:
+            return f"Sum: {arg1 + arg2 + arg3}"
+
+        self.assertEqual(registry.execute('/command_with_many_args 2 2 2'), "Sum: 6")
+
+    def test_command_with_bool_flag(self):
+        registry = CommandRegistry()
+
+        @registry.command('command_with_bool_flag')
+        def command_with_bool_flag(boolean: bool = False) -> str:
+            return "Has flag" if boolean else "No flag"
+
+        self.assertEqual(registry.execute('/command_with_bool_flag'), "No flag")
+        self.assertEqual(registry.execute('/command_with_bool_flag --boolean'), "Has flag")
+
+    def test_command_with_value_flag(self):
+        registry = CommandRegistry()
+
+        @registry.command('command_with_value_flag')
+        def command_with_flag(value: str = 'Default value') -> str:
+            return f"Flag value: {value}"
+
+        self.assertEqual(registry.execute('/command_with_value_flag'), "Flag value: Default value")
+        self.assertEqual(registry.execute('/command_with_value_flag --value Flag'), "Flag value: Flag")
+
+    def test_command_with_args_and_flags(self):
+        registry = CommandRegistry()
+
+        @registry.command('command_with_args_and_flags')
+        def command_with_args_and_flags(name: str, age: int, phrase: str = 'Hello', min_age: int = 18) -> str:
+            greet = f"{phrase}, {name}!"
+            return f"{greet}, You must be at least {min_age} years old to use this command." if age < min_age else greet
+
+        self.assertEqual(registry.execute('/command_with_args_and_flags Alice 17'), "Hello, Alice!, You must be at least 18 years old to use this command.")
+        self.assertEqual(registry.execute('/command_with_args_and_flags Alice 19'), "Hello, Alice!")
+        self.assertEqual(registry.execute('/command_with_args_and_flags Alice 19 --phrase Hi'), "Hi, Alice!")
+        self.assertEqual(registry.execute('/command_with_args_and_flags Alice 19 --phrase Hi --min_age 20'), "Hi, Alice!, You must be at least 20 years old to use this command.")
+
+    def test_unknown_command(self):
+        registry = CommandRegistry()
+        self.assertEqual(registry.execute('/unknown_command'), "Unknown command: unknown_command. Type /help for a list of commands.")
+
+    def test_missing_required_arguments(self):
+        registry = CommandRegistry()
+
+        @registry.command('command_with_required_arg')
+        def command_with_required_arg(arg: str) -> str:
+            return f"{arg}"
+        
+        self.assertTrue("arg" in registry.execute('/command_with_required_arg'))
+        self.assertTrue("required" in registry.execute('/command_with_required_arg'))
+        self.assertTrue("arguments" in registry.execute('/command_with_required_arg'))
+
+    def test_invalid_argument_type(self):
+        registry = CommandRegistry()
+
+        @registry.command('command_with_int_arg')
+        def command_with_int_arg(arg: int) -> str:
+            return f"{arg}"
+
+        self.assertTrue("invalid int" in registry.execute('/command_with_int_arg string'))
+
+if __name__ == '__main__':
+   unittest.main()
+        
+    

--- a/src/planning_permission/utils/command_registry.py
+++ b/src/planning_permission/utils/command_registry.py
@@ -1,0 +1,106 @@
+import argparse
+import shlex
+from typing import Any, Callable, Dict
+from difflib import get_close_matches
+from planning_permission.utils.terminal_input import user_input
+
+class ErrorCatchingArgumentParser(argparse.ArgumentParser):
+    def exit(self, status=0, message=None):
+        if status:
+            raise Exception(message)
+        exit(status)
+
+class CommandRegistry:
+    def __init__(self, exit_on_error = False):
+        self.commands = {}
+        self.default_command = None
+        self._exit_on_error = exit_on_error
+        
+    def command(self, name: str):
+        def decorator(func: Callable):
+            parser = ErrorCatchingArgumentParser(prog=name, add_help=False, exit_on_error=self._exit_on_error)
+            param_names = func.__code__.co_varnames[:func.__code__.co_argcount]
+            param_defaults = func.__defaults__ or ()
+            defaults_dict = dict(zip(param_names[-len(param_defaults):], param_defaults))
+
+            for param, param_type in func.__annotations__.items():
+                if param == "return":  # Ignore return type annotation
+                    continue
+                if param_type == bool:
+                    if defaults_dict.get(param, False):
+                        parser.add_argument(f'--{param}', dest=param, action='store_false')
+                    else:
+                        parser.add_argument(f'--{param}', dest=param, action='store_true')
+                elif param in defaults_dict:
+                    parser.add_argument(f'--{param}', dest=param, type=param_type, default=defaults_dict[param])
+                else:
+                    parser.add_argument(param, type=param_type)
+
+            self.commands[name.lower()] = {'function': func, 'parser': parser}
+            return func
+        return decorator
+
+    def set_default_command(self, func: Callable):
+        self.default_command = func
+
+    def execute(self, command_string: str) -> str:
+        if not command_string.startswith('/'):
+            if self.default_command:
+                return self.default_command(command_string)
+            return "Invalid command format. Commands should start with '/'."
+
+        tokens = shlex.split(command_string[1:])
+        command_name = tokens[0].lower()  # Case-insensitive command names
+        command_args = tokens[1:]
+
+        if command_name == "help":
+            return self._generate_help_text()
+
+        command = self.commands.get(command_name)
+        if not command:
+            suggestion = self._get_command_suggestion(command_name)
+            suggestion_text = f" Did you mean '{suggestion}'?" if suggestion else ""
+            return f"Unknown command: {command_name}. Type /help for a list of commands.{suggestion_text}"
+
+        try:
+            parsed_args = command['parser'].parse_args(command_args)
+            return command['function'](**vars(parsed_args))
+        except Exception as e:
+            return str(e)
+
+    def _generate_help_text(self) -> str:
+        help_texts = ["Available commands:\n"]
+        for command_name, command_data in self.commands.items():
+            usage = command_data['parser'].format_usage()
+            help_texts.append(f"/{command_name}{usage.replace('usage: ', '').replace(command_name, '')}")
+        return "\n".join(help_texts)
+
+    def _get_command_suggestion(self, command_name: str) -> str:
+        """Get the closest matching command name if a user mistypes a command."""
+        matches = get_close_matches(command_name, self.commands.keys(), n=1, cutoff=0.7)
+        return matches[0] if matches else None
+
+if __name__ == '__main__':
+   registry = CommandRegistry()
+   
+   @registry.command('add')
+   def add(a: int, b: int) -> str:
+       return a + b
+   
+   @registry.command('greet')
+   def add(name: str, phrase: str = "Hello") -> str:
+       return f"{phrase}, {name}!"
+   
+   def default_command(msg: str):
+       if msg == 'exit':
+           raise KeyboardInterrupt() # Exit
+       return 'Type "/help" to view commands or "exit" to exit.'
+   
+   registry.default_command = default_command
+   
+   while True: 
+       try:
+           print(registry.execute(user_input("Enter command: ")))
+       except(EOFError, KeyboardInterrupt):
+           print("Exiting...")
+           exit(0)

--- a/src/planning_permission/utils/command_registry.py
+++ b/src/planning_permission/utils/command_registry.py
@@ -83,13 +83,15 @@ class CommandRegistry:
 if __name__ == '__main__':
    registry = CommandRegistry()
    
-   @registry.command('add')
+   @registry.command('add') # Register command with python decorator syntax
    def add(a: int, b: int) -> str:
        return a + b
    
    @registry.command('greet')
-   def add(name: str, phrase: str = "Hello") -> str:
+   def greet(name: str, phrase: str = "Hello") -> str:
        return f"{phrase}, {name}!"
+   
+   registry.command('hi')(greet)  # Alternative syntax
    
    def default_command(msg: str):
        if msg == 'exit':

--- a/src/planning_permission/utils/terminal_input.py
+++ b/src/planning_permission/utils/terminal_input.py
@@ -1,0 +1,57 @@
+import readline
+
+def create_input_with_history(input_fn: callable = input):
+    """
+    This function creates an input function with history.
+    It uses the readline module to add the user input to the history.
+    
+    @param input_fn: The input function to use. Defaults to the built-in input function.
+    @return: A function that gets user input and adds it to the history.
+    """
+    def input_with_history_fn(prompt):
+        """
+        This function gets user input and adds it to the history.
+        
+        @param prompt: The prompt message to display to the user.
+        @return: The input entered by the user.
+        """
+        user_input = input_fn(prompt)
+        if user_input:
+            readline.add_history(user_input)
+            return user_input
+    return input_with_history_fn
+
+def create_input_with_clear(input_fn: callable = input):
+    def input_with_clear_fn(prompt):
+        """
+        This function gets user input and clears the line.
+        It uses ANSI escape codes to move the cursor up and clear the line.
+        \033[A moves the cursor up by one line.
+        \033[K clears the line from the current cursor position to the end of the line.
+        
+        @param prompt: The prompt message to display to the user.
+        @return: The input entered by the user.
+        """
+        user_input = input_fn(prompt)
+        
+        # Use ANSI escape codes to move the cursor up and clear the line
+        # \033[A moves the cursor up by one line
+        # \033[K clears the line from the current cursor position to the end of the line
+        print("\033[A\033[K", end='')
+        
+        return user_input
+    return input_with_clear_fn
+
+
+user_input = create_input_with_history(create_input_with_clear(input))
+
+if __name__ == '__main__':   
+   while True: 
+       try:
+           input = user_input("Enter command: ")
+           if (input == 'exit'):
+               raise KeyboardInterrupt()
+           print(input)
+       except(EOFError, KeyboardInterrupt):
+           print("Exiting...")
+           exit(0)


### PR DESCRIPTION
Functionality responsible for registering and executing chat commands. 


## Changes: 
- add: utils/command_registry.py
- add: test/utils/test_command_registry.py
- add: utils/terminal_input.py


## Example:
```python
from planning_permission.utils.command_registry import CommandRegistry
registry = CommandRegistry()

@registry.command('greet') # Register command with python decorator syntax
   def greet(name: str, phrase: str = "Hello") -> str:
       return f"{phrase}, {name}!"

registry.command('hi')(greet)  # Alternative syntax

print(registry.execute("/greet world")) # Output: Hello, world!
print(registry.execute("/hi world")) # Output: Hello, world!

```

## How to test:
```
# Navigate to root:
cd F-AI

# Run command registry in terminal:
python src/planning_permission/utils/command_registry.py

# Run command registry test:
python src/planning_permission/tests/utils/test_command_registry.py

# Run terminal_input util in terminal:
python src/planning_permission/utils/terminal_input.py
```