### PR TITLE
Chat commands for listing and removing vector collections

### DIFF
--- a/src/planning_permission/app_main_stream.py
+++ b/src/planning_permission/app_main_stream.py
@@ -21,7 +21,7 @@ from planning_permission.chat.stream import create_chat_stream_from_prompt
 from planning_permission.chat.prompt import ChatPrompt
 from planning_permission.chat.template import CHAT_PROMPT_TEMPLATE_ARGS, SCORING_PROMPT_TEMPLATE_ARGS
 
-from utils.command_registry import CommandRegistry, ChatCommands
+from planning_permission.utils.command_registry import CommandRegistry, ChatCommands
 
 load_dotenv(dotenv_path="./.env")
 DB_DIRECTORY = os.environ.get("DB_PATH", "./f-ai.db")

--- a/src/planning_permission/app_main_stream.py
+++ b/src/planning_permission/app_main_stream.py
@@ -40,10 +40,9 @@ if document_store.is_collection_empty():
 
 DEBUG_STREAM = os.environ.get("DEBUG_STREAM", False)
 
-
 # register chat commands here
 commands = ChatCommands(CommandRegistry())
-commands.register(chromadb)
+commands.register(document_store)
 
 
 def use_chat_stream(query: str, debug_fn: Optional[Callable] = None) -> tuple[

--- a/src/planning_permission/store/document_store.py
+++ b/src/planning_permission/store/document_store.py
@@ -69,21 +69,14 @@ class DocumentStore(ICommandSetup):
         query_as_embedding = self.embeddings_generator.create_embeddings(query)
         return self.embeddings_db.query_embedding(query_as_embedding, n_results)
 
-    def handle_list_collections(self):
-        return MarkdownFormatter().list_to_markdown_table(
-            "Collections",
-            self.embeddings_db.list_collections()
-        )
-
-    def handle_reset_collections(self):
-        self.embeddings_db.reset_collections()
-        return "Resetting collections..."
-
     def embedding_commands(self, option: str, parameter: str) -> str:
         handlers = {
             "collection": {
-                "list": self.handle_list_collections,
-                "reset": self.handle_reset_collections,
+                "list": lambda: MarkdownFormatter().list_to_markdown_table(
+                    "Collections",
+                    self.embeddings_db.list_collections()
+                ),
+                "reset": lambda: (self.embeddings_db.reset_collections(), "Collections reset")[1],
             }
         }
         handler = handlers.get(option, {}).get(parameter)

--- a/src/planning_permission/store/document_store.py
+++ b/src/planning_permission/store/document_store.py
@@ -72,9 +72,9 @@ class DocumentStore(ICommandSetup):
     def embedding_commands(self, option: str, parameter: str) -> str:
         handlers = {
             "collection": {
-                "list": lambda: MarkdownFormatter().list_to_markdown_table(
+                "list": lambda: MarkdownFormatter().collection_to_markdown_table(
                     "Collections",
-                    self.embeddings_db.list_collections()
+                    list(self.embeddings_db.list_collections())
                 ),
                 "reset": lambda: (self.embeddings_db.reset_collections(), "Collections reset")[1],
             }

--- a/src/planning_permission/store/document_store.py
+++ b/src/planning_permission/store/document_store.py
@@ -3,8 +3,8 @@ from typing import AsyncGenerator, Any
 from .database import AbstractEmbeddingsDatabase
 from planning_permission.utils.embeddings_handler import AbstractEmbeddingsGenerator, Embeddings
 from planning_permission.utils.file_handler import DocumentHandler, DocumentParserFactory
-from ..utils.command_registry import ICommandSetup, CommandRegistry
-from ..utils.markdown import MarkdownFormatter
+from planning_permission.utils.command_registry import ICommandSetup, CommandRegistry
+from planning_permission.utils.markdown import MarkdownFormatter
 
 
 class DocumentStore(ICommandSetup):

--- a/src/planning_permission/store/document_store.py
+++ b/src/planning_permission/store/document_store.py
@@ -1,10 +1,13 @@
+import os
 from typing import AsyncGenerator, Any
 from .database import AbstractEmbeddingsDatabase
 from planning_permission.utils.embeddings_handler import AbstractEmbeddingsGenerator, Embeddings
 from planning_permission.utils.file_handler import DocumentHandler, DocumentParserFactory
+from ..utils.command_registry import ICommandSetup, CommandRegistry
+from ..utils.markdown import MarkdownFormatter
 
 
-class DocumentStore:
+class DocumentStore(ICommandSetup):
     """
     Class for handling documents and their embeddings in a database.
 
@@ -50,7 +53,7 @@ class DocumentStore:
     def load_document(self, pathname: str, max_words: int = 512):
         file_handler = DocumentHandler()
         chunks = file_handler.convert_docs_to_chunks(pathname, max_words, DocumentParserFactory())
-        print(f"Loaded {len(chunks)} chunks")   # TODO: Remove side effect print
+        print(f"Loaded {len(chunks)} chunks")  # TODO: Remove side effect print
 
         embeddings = self.generate_embeddings(chunks)
         self.add_embeddings(chunks, embeddings)
@@ -65,3 +68,30 @@ class DocumentStore:
     def query(self, query: str, n_results: int) -> AsyncGenerator[str, Any]:
         query_as_embedding = self.embeddings_generator.create_embeddings(query)
         return self.embeddings_db.query_embedding(query_as_embedding, n_results)
+
+    def handle_list_collections(self):
+        return MarkdownFormatter().list_to_markdown_table(
+            "Collections",
+            self.embeddings_db.list_collections()
+        )
+
+    def handle_reset_collections(self):
+        self.embeddings_db.reset_collections()
+        return "Resetting collections..."
+
+    def embedding_commands(self, option: str, parameter: str) -> str:
+        handlers = {
+            "collection": {
+                "list": self.handle_list_collections,
+                "reset": self.handle_reset_collections,
+            }
+        }
+        handler = handlers.get(option, {}).get(parameter)
+
+        if handler:
+            return handler()
+
+        return f"Invalid embeddings command: {option} {parameter}"
+
+    def register_commands(self, command_registry: CommandRegistry):
+        command_registry.command('embeddings')(self.embedding_commands)

--- a/src/planning_permission/tests/utils/test_markdown_formatter.py
+++ b/src/planning_permission/tests/utils/test_markdown_formatter.py
@@ -1,0 +1,58 @@
+import unittest
+
+from planning_permission.utils.markdown import MarkdownFormatter
+
+
+class TestMarkdownFormatter(unittest.TestCase):
+
+    def test_list_to_markdown(self):
+        lst = ["apple", "banana", "cherry"]
+        expected = "* apple\n* banana\n* cherry"
+        result = MarkdownFormatter.list_to_markdown(lst)
+        self.assertEqual(result, expected)
+
+    def test_collection_to_markdown_table_with_set(self):
+        header = "Numbers"
+        collection = {1, 2, 3}
+        result = MarkdownFormatter.collection_to_markdown_table(header, collection)
+        # Note: Sets are unordered, so we just check for existence of a row, not exact ordering.
+        self.assertTrue("| 1 |" in result)
+        self.assertTrue("| 2 |" in result)
+        self.assertTrue("| 3 |" in result)
+
+    def test_collection_to_markdown_table_with_custom_collection(self):
+        header = "Letters"
+
+        # Creating a custom 'Collection' class as an example
+        class Collection:
+            def __iter__(self):
+                return iter(["a", "b", "c"])
+
+        collection = Collection()
+        result = MarkdownFormatter.collection_to_markdown_table(header, collection)
+        expected = "| Letters |\n|---------|\n| a |\n| b |\n| c |"
+        self.assertEqual(result, expected)
+
+    def test_code_block(self):
+        language = "python"
+        code = "print('Hello, world!')"
+        expected = "```python\nprint('Hello, world!')\n```"
+        result = MarkdownFormatter.code_block(language, code)
+        self.assertEqual(result, expected)
+
+    def test_header(self):
+        level = 3
+        text = "This is a header"
+        expected = "### This is a header"
+        result = MarkdownFormatter.header(level, text)
+        self.assertEqual(result, expected)
+
+        # Test for valid header levels
+        with self.assertRaises(ValueError):
+            MarkdownFormatter.header(0, "Invalid header")
+        with self.assertRaises(ValueError):
+            MarkdownFormatter.header(7, "Invalid header")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/planning_permission/utils/command_registry.py
+++ b/src/planning_permission/utils/command_registry.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from abc import ABC, abstractmethod
 import argparse
 import shlex
@@ -9,7 +8,7 @@ from planning_permission.utils.terminal_input import user_input
 
 class ICommandSetup(ABC):
     @abstractmethod
-    def register_commands(self, command_registry: CommandRegistry):
+    def register_commands(self, command_registry: 'CommandRegistry'):
         pass
 
 

--- a/src/planning_permission/utils/markdown.py
+++ b/src/planning_permission/utils/markdown.py
@@ -1,3 +1,6 @@
+from typing import Collection
+
+
 class MarkdownFormatter:
 
     @staticmethod
@@ -5,10 +8,11 @@ class MarkdownFormatter:
         return "\n".join(f"* {item}" for item in lst)
 
     @staticmethod
-    def list_to_markdown_table(header, lst):
+    def collection_to_markdown_table(header, collection):
+        collection_as_list = list(collection)  # Convert collection to list
         header_line = f"| {header} |"
         separator = "|-" + "-" * len(header) + "-|"
-        rows = "\n".join([f"| {item} |" for item in lst])
+        rows = "\n".join([f"| {item} |" for item in collection_as_list])
         return "\n".join([header_line, separator, rows])
 
     @staticmethod
@@ -17,4 +21,6 @@ class MarkdownFormatter:
 
     @staticmethod
     def header(level, text):
+        if not (1 <= level <= 6):
+            raise ValueError("Header level must be between 1 and 6 inclusive.")
         return f"{'#' * level} {text}"

--- a/src/planning_permission/utils/markdown.py
+++ b/src/planning_permission/utils/markdown.py
@@ -1,0 +1,20 @@
+class MarkdownFormatter:
+
+    @staticmethod
+    def list_to_markdown(lst):
+        return "\n".join(f"* {item}" for item in lst)
+
+    @staticmethod
+    def list_to_markdown_table(header, lst):
+        header_line = f"| {header} |"
+        separator = "|-" + "-" * len(header) + "-|"
+        rows = "\n".join([f"| {item} |" for item in lst])
+        return "\n".join([header_line, separator, rows])
+
+    @staticmethod
+    def code_block(language, code):
+        return f"```{language}\n{code}\n```"
+
+    @staticmethod
+    def header(level, text):
+        return f"{'#' * level} {text}"


### PR DESCRIPTION
# Summery
Added commands for listing database vector collections and resetting database (removing everything).

Missing are commands for reloading database with documents.
Loading documents is harder to get correct so the command will come in a future PR.

# Testing
Listing: Test by running command `/embeddings collection list` in chatt.  Result shall be a markdown list with DB collections.
Reset (warning destructive!): Test by running command `/embeddings collection reset`. Message `Collections reset` in the chat window.

# Changes:
* Introduced command registration and execution mechanisms for chat commands.
* Extended database capabilities by adding functions to list, reset, delete, and create/retrieve collections.
* Integrated command handling in chat streams; messages starting with "/" are considered commands.
* Enhanced DocumentStore to handle embedding-related commands and integrated markdown formatting.
* Improved command parsing mechanism by handling errors without crashing the application.
* Implemented a new utility, MarkdownFormatter, which can convert lists to markdown format.
