### PR TITLE
docker/multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -93,4 +93,8 @@ venv/
 */*/*.swp
 */*/*/*.swp
 
-**.DS_Store
+.DS_Store
+**/*/.DS_Store
+
+.env
+**/*/.env

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,96 @@
+# Git
+.git
+.gitignore
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+.docker
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*/__pycache__/
+*/*/__pycache__/
+*/*/*/__pycache__/
+*.py[cod]
+*/*.py[cod]
+*/*/*.py[cod]
+*/*/*/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+**/*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env/
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+*/.ropeproject
+*/*/.ropeproject
+*/*/*/.ropeproject
+
+# Vim swap files
+*.swp
+*/*.swp
+*/*/*.swp
+*/*/*/*.swp
+
+**.DS_Store

--- a/README.md
+++ b/README.md
@@ -8,27 +8,38 @@ This repository contains a collection of Jupyter notebooks and Python scripts th
 
 The current goal of this project is to create a framework that educates us and provides insights into what is possible and not possible to solve using language models.
 
-## Running Docker with Docker Compose
+## Running with Docker locally
 
-To run this project using Docker and Docker Compose, follow these steps:
+To run this project using Docker, follow these steps:
 
-1. Ensure Docker and Docker Compose are installed on your machine. If not, you can download them from the [official Docker website](https://docs.docker.com/get-docker/).
+1. Ensure Docker are installed on your machine. If not, you can download them from the [official Docker website](https://docs.docker.com/get-docker/).
 
 2. Navigate to the project directory in your terminal.
 
 3. Build the Docker image using the following command:
+   ```shell
+   $ docker build -t f-ai-pp:local .
+    
+   # with --platform ⛳️ (apple silicon/m1):
+   $ docker build --platform linux/amd64 -t f-ai-pp:local .
    ```
-   docker-compose build
-   ```
-   **Apple silicon users (m1, m2, ...) need to set target platform:**
-   ```
-   DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose build
-   ```
+  
 4. Once the image is built, run the Docker container using the following command:
+   ```shell
+   # for local development using docker (with mount and port 8001)
+   $ docker run \
+      --name f-ai-pp-local \
+      -e CHAINLIT_PORT=8001 \
+      -p 8001:8001 \
+      -v "$(pwd)"/src/planning_permission/.env:/app/.env \
+      -v "$(pwd)"/src/planning_permission/data:/app/data \
+      -v "$(pwd)"/src/planning_permission:/app/planning_permission \
+      --platform linux/amd64 \
+      f-ai-pp:local
+      
+      # not a apple silicon/m1 user? remove the row 👆 with --platform ⛳️
    ```
-   docker-compose up
-   ```
-5. The application should now be running on your specified port (default is 8888).
+5. The application should now be running on your specified port (8001 or 80).
 
 Please note that any changes made to the codebase will require a rebuild of the Docker image for the changes to take effect.
 


### PR DESCRIPTION
implement dependecy caching in order to improve local development (using docker & m1) by splitting up dockerfile to a multistage build

**How to test**
```
# 1. build docker image (from root)
$ docker build --platform linux/amd64 -t f-ai-pp:local .

# 2.  run it using port 8001 & mount local directories
$ docker run \
      --name f-ai-pp-local \
      -e CHAINLIT_PORT=8001 \
      -p 8001:8001 \
      -v "$(pwd)"/src/planning_permission/.env:/app/.env \
      -v "$(pwd)"/src/planning_permission/data:/app/data \
      --platform linux/amd64 \
      f-ai-pp:local

# 3. run it on port 80 (to simulate production)
$ docker run \
      --name f-ai-pp-local-80 \
      -v "$(pwd)"/src/planning_permission/.env:/app/.env \
      -v "$(pwd)"/src/planning_permission/data:/app/data \
      --platform linux/amd64 \
      f-ai-pp:local

```