### PR TITLE
Implement File Upload and Handling Functionality

### DIFF
--- a/src/planning_permission/.env.example
+++ b/src/planning_permission/.env.example
@@ -15,7 +15,7 @@ DB_PLANNING_PERMISSION_COLLECTION_NAME=planning-docs
 # Documents in this path will be embedded and saved to the database.
 # The embeddings can be used for answering user questions.
 #
-DOCUMENTS_TO_EMBED=path
+PATH_TO_DOCUMENTS=path
 
 # Path to documents to answer questions on
 EXCEL_INPUT_PATH=./data/planing_qa.xlsx

--- a/src/planning_permission/app_main_stream.py
+++ b/src/planning_permission/app_main_stream.py
@@ -12,8 +12,8 @@ from planning_permission.utils.login_handler import ChainlitLoginWithJSONCredent
 from planning_permission.store.document_store import DocumentStore
 from planning_permission.utils.embeddings_handler import OpenAIGenerator
 from planning_permission.store.database import ChromaDB
+from planning_permission.utils.file_handler import ChainlitFile, FileUpload
 
-from numpy import add
 from typing import Dict, Callable, Optional
 from langstream import debug, Stream
 from langstream.contrib import OpenAIChatDelta
@@ -30,10 +30,23 @@ DB_DIRECTORY = os.environ.get("DB_PATH", "./f-ai.db")
 DB_COLLECTION = os.environ.get("DB_PLANNING_PERMISSION_COLLECTION_NAME", "planning_permission")
 DOCUMENTS_TO_EMBED = os.environ.get("DOCUMENTS_TO_EMBED")
 
+
+def upload_callback():
+    return ChainlitFile().upload(
+        accepted_mime_types=["application/pdf", "text/markdown"],
+        uploaded_file_handler=FileUpload(storage_path=os.environ.get("PATH_TO_DOCUMENTS")),
+        max_size_mb=10,
+        max_files=10,
+        timeout=60,
+        rise_on_timeout=True
+    )
+
+
 chromadb = ChromaDB(DB_DIRECTORY, DB_COLLECTION)
 document_store = DocumentStore(
     db=chromadb,
     embeddings_generator=OpenAIGenerator(),
+    file_loader_callback=upload_callback
 )
 
 # populate database with document embeddings if collection empty
@@ -55,7 +68,7 @@ sentry_config = SentryConfig(
     dns=os.environ.get("SENTRY_DSN"),
     level=os.environ.get("SENTRY_LOGGING_LEVEL"),
     event_level=os.environ.get("SENTRY_EVENT_LEVEL"),
-    trace_sample_rate=float(os.environ.get("SENTRY_TRACE_SAMPLE_RATE", 0.0),),
+    trace_sample_rate=float(os.environ.get("SENTRY_TRACE_SAMPLE_RATE", 0.0)),
     environment=os.environ.get("SENTRY_ENVIRONMENT", "development")
 )
 sentry_config.initialize()
@@ -108,7 +121,7 @@ async def on_message(message: str):
     cl_messages_map: Dict[str, cl.Message] = {}
 
     if message.startswith("/"):
-        response = commands.registry.execute(message)
+        response = await commands.registry.execute(message)
         return await cl.Message(content=response).send()
 
     async for output in stream(message):

--- a/src/planning_permission/app_main_stream.py
+++ b/src/planning_permission/app_main_stream.py
@@ -28,7 +28,7 @@ from planning_permission.utils.sentry_config import SentryConfig
 load_dotenv(dotenv_path="./.env")
 DB_DIRECTORY = os.environ.get("DB_PATH", "./f-ai.db")
 DB_COLLECTION = os.environ.get("DB_PLANNING_PERMISSION_COLLECTION_NAME", "planning_permission")
-DOCUMENTS_TO_EMBED = os.environ.get("DOCUMENTS_TO_EMBED")
+PATH_TO_DOCUMENTS = os.environ.get("PATH_TO_DOCUMENTS")
 
 
 def upload_callback():
@@ -51,7 +51,8 @@ document_store = DocumentStore(
 
 # populate database with document embeddings if collection empty
 if document_store.is_collection_empty():
-    document_store.load_document(pathname=DOCUMENTS_TO_EMBED, max_words=256)
+    all_files_in_path = PATH_TO_DOCUMENTS + '*'
+    document_store.load_document(pathname=all_files_in_path, max_words=256)
 
 DEBUG_STREAM = os.environ.get("DEBUG_STREAM", False)
 

--- a/src/planning_permission/store/document_store.py
+++ b/src/planning_permission/store/document_store.py
@@ -1,4 +1,6 @@
+import asyncio
 import os
+import time
 from typing import AsyncGenerator, Any
 from .database import AbstractEmbeddingsDatabase
 from planning_permission.utils.embeddings_handler import AbstractEmbeddingsGenerator, Embeddings
@@ -43,9 +45,11 @@ class DocumentStore(ICommandSetup):
     def __init__(
             self, db: AbstractEmbeddingsDatabase,
             embeddings_generator: AbstractEmbeddingsGenerator,
+            file_loader_callback
     ):
         self.embeddings_db = db
         self.embeddings_generator = embeddings_generator
+        self.file_loader_callback = file_loader_callback
 
     def is_collection_empty(self):
         return self.embeddings_db.is_collection_empty()

--- a/src/planning_permission/store/document_store.py
+++ b/src/planning_permission/store/document_store.py
@@ -86,5 +86,17 @@ class DocumentStore(ICommandSetup):
 
         return f"Invalid embeddings command: {option} {parameter}"
 
+    def file_commands(self, option: str) -> str:
+        handlers = {
+            "upload": lambda: (asyncio.run(self.file_loader_callback()), "Upload complete")[1],
+        }
+        handlers = handlers.get(option)
+
+        if handlers:
+            return handlers()
+
+        return f"Invalid file command: {option}"
+
     def register_commands(self, command_registry: CommandRegistry):
         command_registry.command('embeddings')(self.embedding_commands)
+        command_registry.command('file')(self.file_commands)

--- a/src/planning_permission/tests/test_document_store.py
+++ b/src/planning_permission/tests/test_document_store.py
@@ -53,7 +53,7 @@ class TestDocumentStore(unittest.TestCase):
     def setUp(self):
         self.db = FakeEmbeddingsDatabase()
         self.embeddings_generator = FakeEmbeddingsGenerator()
-        self.document_store = DocumentStore(self.db, self.embeddings_generator)
+        self.document_store = DocumentStore(self.db, self.embeddings_generator, lambda: "fake_file_callback")
 
     def test_load_document(self):
         with patch.object(DocumentHandler, "convert_docs_to_chunks", return_value=["chunk1", "chunk2"]):

--- a/src/planning_permission/tests/test_file_handler.py
+++ b/src/planning_permission/tests/test_file_handler.py
@@ -1,6 +1,6 @@
 import unittest
-from unittest.mock import MagicMock
-from planning_permission.utils.file_handler import DocumentHandler, AbstractDocumentParser
+from unittest.mock import MagicMock, mock_open, patch
+from planning_permission.utils.file_handler import DocumentHandler, AbstractDocumentParser, FileUpload, FileObject
 
 
 class TestChunkStringsMethod(unittest.TestCase):
@@ -85,6 +85,43 @@ class TestParseDocsMethod(unittest.TestCase):
         )
         mock_print.assert_any_call("Parsing file1.md...")
         mock_print.assert_any_call("Parsing file2.pdf...")
+
+
+class TestFileUpload(unittest.TestCase):
+
+    def setUp(self):
+        self.storage_path = "/path/to/storage"
+        self.file_upload = FileUpload(self.storage_path)
+
+    def test_save_file(self):
+        file_objects = [
+            FileObject(name="file1.txt", path="", size=15, type="text/plain", content=b"Hello, world!"),
+            FileObject(name="file2.txt", path="", size=12, type="text/plain", content=b"Hello, File!"),
+        ]
+        destination_directory = "/path/to/destination"
+
+        m = mock_open()
+        with patch('builtins.open', m), patch('os.makedirs') as mock_makedirs:
+            self.file_upload.save_file(file_objects, destination_directory)
+
+        mock_makedirs.assert_called_once_with(destination_directory, exist_ok=True)
+        m.assert_any_call('/path/to/destination/file1.txt', 'wb')
+        m.assert_any_call('/path/to/destination/file2.txt', 'wb')
+        m().write.assert_any_call(b"Hello, world!")
+        m().write.assert_any_call(b"Hello, File!")
+
+    def test_handle_uploaded_files(self):
+        file_objects = [
+            FileObject(name="file3.txt", path="", size=15, type="text/plain", content=b"Hello, world!"),
+            FileObject(name="file4.txt", path="", size=12, type="text/plain", content=b"Hello, File!"),
+        ]
+
+        with patch.object(self.file_upload, 'save_file') as mock_save_file:
+            import asyncio
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(self.file_upload.handle_uploaded_files(file_objects))
+
+        mock_save_file.assert_called_once_with(file_objects=file_objects, destination_directory=self.storage_path)
 
 
 if __name__ == '__main__':

--- a/src/planning_permission/tests/test_file_handler.py
+++ b/src/planning_permission/tests/test_file_handler.py
@@ -119,7 +119,10 @@ class TestFileUpload(unittest.TestCase):
         with patch.object(self.file_upload, 'save_file') as mock_save_file:
             import asyncio
             loop = asyncio.get_event_loop()
-            loop.run_until_complete(self.file_upload.handle_uploaded_files(file_objects))
+            try:
+                loop.run_until_complete(self.file_upload.handle_uploaded_files(file_objects))
+            finally:
+                loop.close()
 
         mock_save_file.assert_called_once_with(file_objects=file_objects, destination_directory=self.storage_path)
 


### PR DESCRIPTION
## Description
This Pull Request introduces file upload functionality.
Future PR will add read of files to DB as embeddings.

## Testing
1. Remove .env variable `DOCUMENTS_TO_EMBED`.
2. Add .env variable `PATH_TO_DOCUMENTS=./data/docs/`.
3. Start Chainlit `chainlit run app_main_stream.py`.
4. Write command `/file upload` in the chat. This will trigger a file upload message.
5: Upload a supported file (PDF, Markdown) and check that the file gets uploaded to directory `PATH_TO_DOCUMENTS=./data/docs/`.

Supported upload files are currently PDF and Markdown but can easily be extended.