### PR TITLE
Document management: Reload files

### DIFF
--- a/src/planning_permission/app_main_stream.py
+++ b/src/planning_permission/app_main_stream.py
@@ -46,13 +46,13 @@ chromadb = ChromaDB(DB_DIRECTORY, DB_COLLECTION)
 document_store = DocumentStore(
     db=chromadb,
     embeddings_generator=OpenAIGenerator(),
-    file_loader_callback=upload_callback
+    file_loader_callback=upload_callback,
+    document_path=PATH_TO_DOCUMENTS
 )
 
 # populate database with document embeddings if collection empty
 if document_store.is_collection_empty():
-    all_files_in_path = PATH_TO_DOCUMENTS + '*'
-    document_store.load_document(pathname=all_files_in_path, max_words=256)
+    document_store.load_all_documents_in_path()
 
 DEBUG_STREAM = os.environ.get("DEBUG_STREAM", False)
 

--- a/src/planning_permission/store/database.py
+++ b/src/planning_permission/store/database.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from abc import ABC, abstractmethod
 from typing import Any, AsyncGenerator
@@ -85,7 +86,7 @@ class AbstractEmbeddingsDatabase(ABC):
         pass
 
     @abstractmethod
-    def reset_collections(self):
+    def reset_collection(self):
         """
         Resets all the collections in the database.
 
@@ -128,6 +129,18 @@ class AbstractEmbeddingsDatabase(ABC):
         """
         pass
 
+    @abstractmethod
+    def create_collection(self, collection_name: str):
+        """
+        Creates a new collection in the database.
+
+        Parameters
+        ----------
+        collection_name : str
+            The name of the collection to create.
+        """
+        pass
+
 
 class ChromaDB(AbstractEmbeddingsDatabase):
     """
@@ -160,7 +173,8 @@ class ChromaDB(AbstractEmbeddingsDatabase):
                 allow_reset=True
             )
         )
-        self.collection = self.client.get_or_create_collection(collection_name)
+        self.collection_name = collection_name
+        self.collection = self.client.get_or_create_collection(self.collection_name)
 
     def is_collection_empty(self):
         return self.collection.count() == 0
@@ -184,11 +198,15 @@ class ChromaDB(AbstractEmbeddingsDatabase):
     def list_collections(self):
         return self.client.list_collections()
 
-    def reset_collections(self):
+    def reset_collection(self):
         self.client.reset()
+        self.collection = self.client.get_or_create_collection(self.collection_name)
 
     def delete_collection(self, collection_name: str):
         self.client.delete_collection(collection_name)
 
     def get_or_create_collection(self, collection_name: str):
         return self.client.get_or_create_collection(collection_name)
+
+    def create_collection(self, collection_name: str):
+        self.client.create_collection(collection_name)

--- a/src/planning_permission/tests/test_document_store.py
+++ b/src/planning_permission/tests/test_document_store.py
@@ -31,7 +31,7 @@ class FakeEmbeddingsDatabase(AbstractEmbeddingsDatabase):
     def list_collections(self):
         return self.collections
 
-    def reset_collections(self):
+    def reset_collection(self):
         self.collections = []
 
     def register_commands(self, command_registry: CommandRegistry):
@@ -53,7 +53,12 @@ class TestDocumentStore(unittest.TestCase):
     def setUp(self):
         self.db = FakeEmbeddingsDatabase()
         self.embeddings_generator = FakeEmbeddingsGenerator()
-        self.document_store = DocumentStore(self.db, self.embeddings_generator, lambda: "fake_file_callback")
+        self.document_store = DocumentStore(
+            self.db,
+            self.embeddings_generator,
+            lambda: "fake_file_callback",
+            "fake_document_path"
+        )
 
     def test_load_document(self):
         with patch.object(DocumentHandler, "convert_docs_to_chunks", return_value=["chunk1", "chunk2"]):
@@ -89,11 +94,6 @@ class TestDocumentStore(unittest.TestCase):
         result = self.document_store.embedding_commands("collection", "list")
         expected = "| Collections |\n|-------------|\n| collection1 |\n| collection2 |"
         self.assertEqual(result, expected)
-
-    def test_embedding_commands_reset_collections(self):
-        self.db.add_embeddings(["collection1", "collection2"], ["embedding1", "embedding2"])
-        self.document_store.embedding_commands("collection", "reset")
-        self.assertEqual(len(self.db.list_collections()), 0)  # Ensuring collections are reset
 
     def test_embedding_commands_invalid(self):
         result = self.document_store.embedding_commands("invalid_option", "invalid_parameter")


### PR DESCRIPTION
## Description
Handling for reloading files into document DB.

## Test
Run chat command `/embeddings collection reload` to reload files into DB.

Loading of files will take some time depending on file size. There is currently missing a indication for progress.