### PR TITLE
Feat/vectorize file

### DIFF
--- a/fai-rag-app/fai-backend/.gitignore
+++ b/fai-rag-app/fai-backend/.gitignore
@@ -189,3 +189,6 @@ cython_debug/
 #.idea/
 
 static/
+
+uploads/
+vector_db/

--- a/fai-rag-app/fai-backend/fai_backend/documents/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/documents/routes.py
@@ -96,10 +96,9 @@ async def upload_and_vectorize_handler(
     await vector_service.create_collection(collection_name=upload_directory_name)
 
     parsed_files = file_service.parse_files(upload_path)
-    artifacts = [str(elem) for elem in parsed_files]
     await vector_service.add_artifacts_to_collection(
         collection_name=upload_directory_name,
-        artifacts=artifacts,
+        artifacts=parsed_files,
     )
 
     return view(

--- a/fai-rag-app/fai-backend/fai_backend/documents/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/documents/routes.py
@@ -96,9 +96,9 @@ async def upload_and_vectorize_handler(
     await vector_service.create_collection(collection_name=upload_directory_name)
 
     parsed_files = file_service.parse_files(upload_path)
-    await vector_service.add_artifacts_to_collection(
+    await vector_service.add_documents_without_id_to_empty_collection(
         collection_name=upload_directory_name,
-        artifacts=parsed_files,
+        documents=parsed_files,
     )
 
     return view(

--- a/fai-rag-app/fai-backend/fai_backend/files/file_parser.py
+++ b/fai-rag-app/fai-backend/fai_backend/files/file_parser.py
@@ -28,7 +28,7 @@ class ParserFactory:
 
         if mime_type == 'application/pdf':
             return PDFParser()
-        if mime_type == 'text/markdown':
+        if mime_type == 'text/plain':
             return MarkdownParser()
 
         raise ValueError(f'Unsupported file type: {mime_type}')

--- a/fai-rag-app/fai-backend/fai_backend/files/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/files/service.py
@@ -75,7 +75,7 @@ class FileUploadService:
             0]
         return os.path.join(self.upload_dir, latest_directory)
 
-    def parse_files(self, src_directory_path: str):
+    def parse_files(self, src_directory_path: str) -> list[str]:
         parsed_files = []
 
         upload_date = datetime.fromtimestamp(os.path.getctime(src_directory_path))
@@ -84,7 +84,7 @@ class FileUploadService:
         for file in files:
             parser = ParserFactory.get_parser(file.path)
             parsed_file = parser.parse(file.path)
-            parsed_files.extend(parsed_file)
+            parsed_files.extend([str(elem) for elem in parsed_file])
 
         return parsed_files
 

--- a/fai-rag-app/fai-backend/fai_backend/files/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/files/service.py
@@ -10,6 +10,8 @@ from pydantic import ByteSize
 from fai_backend.files.file_parser import ParserFactory
 from fai_backend.files.models import FileInfo
 
+PROJECT_PATH_PREFIX = 'proj'
+
 
 class FileUploadService:
     def __init__(self, upload_dir: str):
@@ -18,8 +20,8 @@ class FileUploadService:
 
     def _generate_upload_path(self, project_id: str) -> str:
         timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
-        upload_session_uuid = str(uuid.uuid4())
-        path = f'project_{project_id}_{timestamp}_{upload_session_uuid}'
+        upload_session_uuid = str(uuid.uuid4())[:8]
+        path = f'{PROJECT_PATH_PREFIX}_{project_id}_{timestamp}_{upload_session_uuid}'
         full_path = os.path.join(self.upload_dir, path)
         os.makedirs(full_path, exist_ok=True)
         return full_path
@@ -53,7 +55,7 @@ class FileUploadService:
         return file_infos
 
     def list_files(self, project_id: str) -> list[FileInfo]:
-        project_directories = [d for d in os.listdir(self.upload_dir) if d.startswith(f'project_{project_id}_')]
+        project_directories = [d for d in os.listdir(self.upload_dir) if d.startswith(f'{PROJECT_PATH_PREFIX}_{project_id}_')]
         if not project_directories:
             return []
 
@@ -65,7 +67,7 @@ class FileUploadService:
         return self.get_file_infos(latest_directory_path, upload_date)
 
     def get_latest_upload_path(self, project_id: str) -> str | None:
-        project_directories = [d for d in os.listdir(self.upload_dir) if d.startswith(f'project_{project_id}_')]
+        project_directories = [d for d in os.listdir(self.upload_dir) if d.startswith(f'{PROJECT_PATH_PREFIX}_{project_id}_')]
         if not project_directories:
             return None
 

--- a/fai-rag-app/fai-backend/fai_backend/vector/router_error_handler.py
+++ b/fai-rag-app/fai-backend/fai_backend/vector/router_error_handler.py
@@ -15,7 +15,7 @@ def handle_errors(f):
         except KeyError as ke:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Resource not found."
+                detail="Resource not found: " + str(ke)
             )
         except Exception as e:
             # Log exception details here if logging is set up

--- a/fai-rag-app/fai-backend/fai_backend/vector/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/vector/routes.py
@@ -1,5 +1,3 @@
-from pathlib import Path, PurePosixPath
-
 from fastapi import Depends, APIRouter
 
 from fai_backend.files.dependecies import get_file_upload_service
@@ -52,16 +50,16 @@ async def add_to_collection(
         json: VectorData,
         vector_service: VectorService = Depends(get_vector_service)
 ):
-    artifacts = [str(elem) for elem in json.artifacts]
-    await vector_service.add_artifacts_to_collection(
+    documents = [str(elem) for elem in json.documents]
+    await vector_service.add_documents_without_id_to_empty_collection(
         collection_name=collection_name,
-        artifacts=artifacts,
+        documents=documents,
     )
 
     return {
         "message": "Successfully added to collection",
         "collection_name": collection_name,
-        "added_count": len(artifacts),
+        "added_count": len(documents),
     }
 
 
@@ -110,7 +108,7 @@ async def vectorize_files(
     await vector_service.create_collection(collection_name=directory_name)
 
     parsed_files = file_service.parse_files(directory_path)
-    await vector_service.add_artifacts_to_collection(
+    await vector_service.add_documents_without_id_to_empty_collection(
         collection_name=directory_name,
-        artifacts=parsed_files,
+        documents=parsed_files,
     )

--- a/fai-rag-app/fai-backend/fai_backend/vector/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/vector/routes.py
@@ -109,8 +109,10 @@ async def vectorize_files(
         vector_service: VectorService = Depends(get_vector_service),
 ):
     upload_directory_name = upload_path.split('/')[-1]
+
+    # Upload directory name will be used as the collection which is limited to 62 characters
     if len(upload_directory_name) > 62:
-        raise ValueError("Generated path exceeds the 62 character limit")
+        raise ValueError("Directory name exceeds the 62 character limit, cannot create collection with same name")
     if len(upload_directory_name) == 0:
         raise ValueError("Generated path is empty")
 

--- a/fai-rag-app/fai-backend/fai_backend/vector/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/vector/routes.py
@@ -102,15 +102,15 @@ async def list_collections(
 @router.post('/vector/vectorize_files', response_model=dict)
 @handle_errors
 async def vectorize_files(
-        upload_path: str,
+        directory_path: str,
         vector_service: VectorService = Depends(get_vector_service),
         file_service: FileUploadService = Depends(get_file_upload_service),
 ):
-    upload_directory_name = upload_path.split('/')[-1]
-    await vector_service.create_collection(collection_name=upload_directory_name)
+    directory_name = directory_path.split('/')[-1]
+    await vector_service.create_collection(collection_name=directory_name)
 
-    parsed_files = file_service.parse_files(upload_path)
+    parsed_files = file_service.parse_files(directory_path)
     await vector_service.add_artifacts_to_collection(
-        collection_name=upload_directory_name,
+        collection_name=directory_name,
         artifacts=parsed_files,
     )

--- a/fai-rag-app/fai-backend/fai_backend/vector/schema.py
+++ b/fai-rag-app/fai-backend/fai_backend/vector/schema.py
@@ -2,4 +2,4 @@ from pydantic import BaseModel
 
 
 class VectorData(BaseModel):
-    artifacts: list[str]
+    documents: list[str]

--- a/fai-rag-app/fai-backend/fai_backend/vector/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/vector/service.py
@@ -21,23 +21,23 @@ class VectorService:
             collection_name: str,
             ids: OneOrMany[str],
             documents: Optional[OneOrMany[str]],
-    ):
+    ) -> None:
         await self.vector_db.add(
             collection_name=collection_name,
             ids=ids,
             documents=documents,
         )
 
-    async def add_artifacts_to_collection(
+    async def add_documents_without_id_to_empty_collection(
             self,
             collection_name: str,
-            artifacts: list[str]
+            documents: list[str]
     ) -> None:
-        ids = [str(i) for i in range(len(artifacts))]
+        ids = [str(i) for i in range(len(documents))]
         await self.add_to_collection(
             collection_name=collection_name,
             ids=ids,
-            documents=artifacts,
+            documents=documents,
         )
 
     async def query_from_collection(

--- a/fai-rag-app/fai-backend/fai_backend/vector/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/vector/service.py
@@ -33,6 +33,11 @@ class VectorService:
             collection_name: str,
             documents: list[str]
     ) -> None:
+        """
+        Add documents to a collection without specifying ID's
+
+        The collection should be empty before calling this method to avoid ID conflicts.
+        """
         ids = [str(i) for i in range(len(documents))]
         await self.add_to_collection(
             collection_name=collection_name,

--- a/fai-rag-app/fai-backend/fai_backend/vector/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/vector/service.py
@@ -28,6 +28,18 @@ class VectorService:
             documents=documents,
         )
 
+    async def add_artifacts_to_collection(
+            self,
+            collection_name: str,
+            artifacts: list[str]
+    ) -> None:
+        ids = [str(i) for i in range(len(artifacts))]
+        await self.add_to_collection(
+            collection_name=collection_name,
+            ids=ids,
+            documents=artifacts,
+        )
+
     async def query_from_collection(
             self,
             collection_name: str,

--- a/fai-rag-app/fai-backend/tests/vector/test_in_memory_vector.py
+++ b/fai-rag-app/fai-backend/tests/vector/test_in_memory_vector.py
@@ -14,6 +14,11 @@ async def memory_vector_db():
     await db_instance.reset()
 
 
+@pytest_asyncio.fixture
+async def vector_service(memory_vector_db):
+    return VectorService(memory_vector_db)
+
+
 @pytest.mark.asyncio
 async def test_add(memory_vector_db):
     collection_name = "test_collection"
@@ -135,3 +140,20 @@ async def test_update_id_document_and_expect_update(memory_vector_db):
     )
 
     assert query_non_updated_document["ids"] == [['id2']]
+
+
+@pytest.mark.asyncio
+async def test_add_artifacts_to_collection_then_query_correct_result(vector_service):
+    collection_name = "animal_collection"
+    artifacts = ["Cat", "Dog"]
+
+    await vector_service.create_collection(collection_name)
+    await vector_service.add_artifacts_to_collection(collection_name, artifacts)
+
+    results = await vector_service.query_from_collection(
+        collection_name=collection_name,
+        query_texts=["Cat"],
+        n_results=1
+    )
+
+    assert results["ids"] == [['0']]

--- a/fai-rag-app/fai-backend/tests/vector/test_in_memory_vector.py
+++ b/fai-rag-app/fai-backend/tests/vector/test_in_memory_vector.py
@@ -143,12 +143,12 @@ async def test_update_id_document_and_expect_update(memory_vector_db):
 
 
 @pytest.mark.asyncio
-async def test_add_artifacts_to_collection_then_query_correct_result(vector_service):
+async def test_add_documents_without_id_to_collection_then_query_correct_result(vector_service):
     collection_name = "animal_collection"
-    artifacts = ["Cat", "Dog"]
+    documents = ["Cat", "Dog"]
 
     await vector_service.create_collection(collection_name)
-    await vector_service.add_artifacts_to_collection(collection_name, artifacts)
+    await vector_service.add_documents_without_id_to_empty_collection(collection_name, documents)
 
     results = await vector_service.query_from_collection(
         collection_name=collection_name,


### PR DESCRIPTION
Added endpoint and functionality for vectorizing files.

## Pre reqs
Switch from using OpenAI´s tokenizer for vector database, to a local tokenizer. The local tokenizer will generate warnings if default values are used. Fix warnings by setting parallelism flag to false:
Disable Pytorch parallelism for tokenizers by setting `TOKENIZERS_PARALLELISM=false` in `.env`.
Example and explanation can be find in `fai-rag-app/.env.example`.

## pytest
Test should preferably be run with in memory `.env` configuration. 
Example configuration can be find under section "Appendix" in this PR.

## Manual test
Example below on how to upload file and query created vector database. Example uses `curl` but could be also be done through the Swager documentation `http://0.0.0.0:8000/docs`
1) starting the back and front end. 
2) Login and navigate to `http://0.0.0.0:8000/documents/upload`.
3) Upload PDF file. A test file can be found under `tests/parse_and_vectorize/test_data/Bevprogram_Raa_1991_sbf.pdf`
This step will create a folder with a unique name -> upload files -> create a vector database collection with the same unique name as previously created folder name -> parse and add files as document in created collection.
4) List created collection with curl command:
```
curl -X 'GET' \
  'http://0.0.0.0:8000/api/vector/list_collections' \
  -H 'accept: application/json'
 ```
There should be one collection listed in the response (if first time running this branch).
Response should look something like this:
```json
{
  "message": "Successfully listed collections",
  "collections": [
    "proj_65f2cbeb6e58fb353b576d6a_20240510104100_b3732362"
  ]
}
```
5) Query collection with copying collection name from step 4 into curl command:
```
curl -X 'GET' \
  'http://0.0.0.0:8000/api/vector/query_collection?collection_name=proj_65f2cbeb6e58fb353b576d6a_20240510104100_b3732362&query_text=Beh%C3%B6ver%20jag%20ans%C3%B6ka%20bygglov%20f%C3%B6r%20attefallshus%3F&n_results=10' \
  -H 'accept: application/json'
 ```

Above curl command should return:
```json
{
  "message": "Successfully queried collection",
  "collection_name": "proj_65f2cbeb6e58fb353b576d6a_20240510104100_b3732362",
  "results": {
    "ids": [
      [
        "175",
        "81",
        "212",
        "8",
        "113",
        "165",
        "47",
        "37",
        "172",
        "36"
      ]
    ],
    "distances": [
      [
        0.929482102394104,
        0.9465630054473877,
        0.9475446568492114,
        0.9500824213027954,
        0.9634616374969482,
        0.967968225479126,
        0.9704232215881348,
        0.9725326895713806,
        0.9736354351043701,
        0.9858536720275879
      ]
    ],
    "metadatas": [
      [
        null,
        null,
        null,
        null,
        null,
        null,
        null,
        null,
        null,
        null
      ]
    ],
    "embeddings": null,
    "documents": [
      [
        "En rad byggnader i bevaringsprogrammet har betecknats som särskilt värdefulla, trots att de är förändrade i förhållande till ursprunget. I vissa fall kan en byggnads succesiva föränd ring betraktas som en del av dess historia, och behöver ej förringa dess värde. Många gånger finns också goda möjligheter att i samband med renovering återställa ett förändrat hus till ett för byggnadstraditionen på Råå mer typiskt utseende, vad gäller exempelvis fasadmaterial, färgsättning, fönstertyp etc. Här",
        "I söder utgjorde Råå-ån alltjämt gräns för samhället. Först under 1800-talets sista år började bostadsbebyggelsen på Örby bys marker att växa fram och efter sekelskiftet fortsattes bebyggelsen söder om Råå-ån.\n\nHörnavskiirningar i gatukorsningar föreskrevs i byggntUisordningen. Här vid Lubecksgatan nr 18 plJlnerades RepslJlgaregatan att gå fram genom nuvarande kvarteret Fregatten.\n\nByggnadsnämnd och byggnadsordning",
        "På Pålstorps ängar, eller Örby ängar som området kallas idag, söder om Råå-ån, bör jade man bygga bostadshus strax efter sekel skiftet 1900. Denna trakt, som under alla tider varit sank på grund av Råå-åns olika utlopp, betraktades inte som beboelig och de första som bosatte sig där ansågs \" förvisade\" . Området kallades till och med för \"Djävuls ön\".",
        "Inställningen till bevarande har under senare år förändrats till förmån för helheten i kulturmiljön. Av denna orsak och av utrymmesskäl har det ur sprungliga förslagets katalog över enskilda faStigheter utelämnats. Slutre digering och områdesbeskrivningar har gjorts av vik. stadsantikvarie Inger Andersson.\n\nHelsingborg 27 augusti 1991 Uno Aldegren kommunalråd,\n\nordf. i Helsingborgs bevaringskommitte\n\n3\n\nSkiss från Rdå hilmn, utfärd av arkitekten Ferdinand Boberg 1916. Nordiska museet.\n\nl -\n\n_",
        "detaljerat sätt redovisar bebyggelsen i plan, finner man att flera av fastigheterna består av vinkelbyggda enheter. Uthusdelen kunde även förenas med bostadsdelen till en lång sammanhängande huskropp.\n\nPlanformerna i de äldsta boninghusen bygger på den smala längan, som vid behov kunde förlängas med nya binningar.\n\nH~~SINCBORC RAA VARVSGATAN 17 KV RODDAREN 4'1'7\n\n------------_._.~.....\n\nLADA\n\nLott.\n\nLADA\n\nJro\".\"::\n\n-----.------.n. :! rÅR~ ii ;;:::::;\n\nJ:ATTE.\n\n.~::~\n\n\\\\::;:~.:.::\n\n\\:AI'IMf.",
        "Bevara årsringarna i bebyggelsen som illustrerar samhällets tillväxt och förändring.\n\nBevara i största möjliga utsträckning de ursprungliga byggnadsdelar och detaljer som förmedlar upplevelsen av att Rååbebyggelsen är ålderdomlig och genuin.\n\nMöjligheter att skydda den kulturhistoriskt värdefulla miljön\n\nSom redovisades i inledningen utgör Råå ett riksintresse för kulturminnesvården. I över siktsplanen för Helsingborg redovisas intres seområdet på en översiktligt nivå, men",
        "I samband med utmarksdelningen gjordes också den första karteringen som överskåd ligt redovisar fiskelägets bebyggelse. Kartbil den bör dock ej tolkas alltför exakt -lantmäte riförättningen syftade ej till att dokumentera\n\n11\n\nPåJstorps\n\nr 05V,•\n\n\\\\I~, n~\n\nI'",
        "~...... 0\"'-:- /--\"'-!> •. ,,\"~.~ ,.r...to \"\"\"O \"\"7'cf/\"\"\"'\" .,.,.r y \"/.>--.... -Ary ?- ~,. .\"./.\n\nSkiss över det danska liigret vid Råå 17090 Krigsarkivet.\n\nRåå under krigs- och orostider",
        "En för kultunninnesvården och byggnadsvår den central fonnulering finns i PBL 3:12 §:\n\n\"Byggnader, som är särskilt värdefulla från historisk, kulturhistorisk, miljömässig eller konstnärlig synpunkt eller som ingår i ett bebyggclseområde av denna karaktär, får inte förvanskas.\"\n\nParagrafen har utformats så att skyddet mot förvanskning kan hävdas i varje enskilt tillståndsärende, utan att någon ersättnings skyldighet utlöses.",
        "Mycket tyder dock på att en permanent bosättning växte fram i de skånska fiskeläge na senast under 1600-talets andra hälft. Efter Skånes övergång till Sverige skedde omfat tande jordrannsakningar som underlag för ny skatteläggning, och i den jordebok som upprättades 1673 förteckna s tolv strand fiskehus vid Råå.\n\n9\n\n, - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ,\n\n~\n\n,~.,I\n\n(\n\n-----\"\"-\"\"'------~L..:~ ~ ."
      ]
    ],
    "uris": null,
    "data": null
  }
}
```

## Appendix
Example `.env.test` configuration:
``` text
# General
ENV_MODE='development'
LOG_LEVEL="debug"

# DB
APP_DB="memory"
APP_VECTOR_DB="memory"

## Mongo DB
MONGO_DB_NAME="folkets-ai"


## AUTH / JWT
SECRET_KEY="my-secret-key"

## AUTH / Pin
FIXED_PIN="1234"

# MAIL
MAIL_SENDER_NAME="Folkets AI App"
MAIL_SENDER_EMAIL="no-reply@localhost.dev"
MAIL_CLIENT="console"

## Project Init
APP_PROJECT_NAME="Folkets AI App"
APP_ADMIN_EMAIL="my_email@helsingborg.se"

```