### PR TITLE
Feat: Refactored qaf and added ability to copy a conversation

### DIFF
--- a/fai-rag-app/fai-backend/fai_backend/conversations/models.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/models.py
@@ -34,9 +34,9 @@ class Conversation(BaseModel):
     created_by: str
     participants: List[str]
     messages: List[Message] = Field(default_factory=list)
-    conversation_id: UUID4 = Field(default_factory=uuid4)
-    conversation_root_id: UUID4 | None = None
-    conversation_active_id: UUID4
+    conversation_id: UUID4 = Field(default_factory=uuid4)   # ID used to track the conversation and its copies
+    conversation_root_id: UUID4 | None = None               # Any copy of the conversation will have the same root ID
+    conversation_active_id: UUID4                           # The root conversation will track the active conversation
     timestamp: Timestamp = Timestamp()
     metadata: dict = Field(default_factory=dict)
     tags: List[str] | None = Field(default_factory=list)

--- a/fai-rag-app/fai-backend/fai_backend/conversations/models.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/models.py
@@ -1,5 +1,6 @@
+from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, UUID4
 
 from fai_backend.schema import Timestamp
 
@@ -22,11 +23,23 @@ class Message(BaseModel):
     metadata: dict | None = Field(default_factory=dict)
 
 
+class Thread(BaseModel):
+    id: UUID4 = Field(default_factory=uuid4)
+    thread_name: str
+    copy_of_thread_with_id: str | None = None
+    active_flag: bool
+    timestamp: Timestamp = Timestamp()
+    messages: list[Message]
+    feedback: Feedback | None = None
+    metadata: dict | None = Field(default_factory=dict)
+
+
 class Conversation(BaseModel):
     id: str
     type: str = 'conversation'
     created_by: str
     participants: list[str]
+    threads: list[Thread]
     messages: list[Message]
     timestamp: Timestamp = Timestamp()
     metadata: dict = Field(default_factory=dict)

--- a/fai-rag-app/fai-backend/fai_backend/conversations/schema.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/schema.py
@@ -1,4 +1,7 @@
-from pydantic import BaseModel, Field
+from uuid import uuid4
+
+from bson import ObjectId
+from pydantic import BaseModel, Field, UUID4
 
 from fai_backend.conversations.models import Conversation, Feedback, Message
 
@@ -21,6 +24,7 @@ class CreateFeedbackRequest(BaseModel):
 
 
 class CreateMessageRequest(BaseModel):
+    id: UUID4 = Field(default_factory=uuid4)
     user: str = None
     created_by: str = None
     content: str = None
@@ -28,18 +32,20 @@ class CreateMessageRequest(BaseModel):
     metadata: dict = Field(default_factory=dict)
 
 
-class CreateThreadRequest(BaseModel):
-    thread_name: str
-    copy_of_thread_with_id: str = None
-    active_flag: bool
-    messages: list[CreateMessageRequest]
-    feedback: CreateFeedbackRequest = None
-    metadata: dict | None = Field(default_factory=dict)
-
-
 class CreateConversationRequest(BaseModel):
-    project_id: str
-    threads: list[CreateThreadRequest] | None = Field(default_factory=list)
-    messages: list[CreateMessageRequest]
+    id: ObjectId = Field(default_factory=ObjectId)
+    type: str = 'conversation'
+    messages: list[CreateMessageRequest] = Field(default_factory=list)
     metadata: dict = Field(default_factory=dict)
     tags: list[str] | None = Field(default_factory=list)
+    conversation_id: UUID4 = uuid4()
+    conversation_root_id: UUID4 = None
+    conversation_active_id: UUID4 = None
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.conversation_active_id = self.conversation_id
+
+    class Config:
+        arbitrary_types_allowed = True
+        orm_mode = True

--- a/fai-rag-app/fai-backend/fai_backend/conversations/schema.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/schema.py
@@ -28,7 +28,18 @@ class CreateMessageRequest(BaseModel):
     metadata: dict = Field(default_factory=dict)
 
 
+class CreateThreadRequest(BaseModel):
+    thread_name: str
+    copy_of_thread_with_id: str = None
+    active_flag: bool
+    messages: list[CreateMessageRequest]
+    feedback: CreateFeedbackRequest = None
+    metadata: dict | None = Field(default_factory=dict)
+
+
 class CreateConversationRequest(BaseModel):
     project_id: str
+    threads: list[CreateThreadRequest] | None = Field(default_factory=list)
     messages: list[CreateMessageRequest]
     metadata: dict = Field(default_factory=dict)
+    tags: list[str] | None = Field(default_factory=list)

--- a/fai-rag-app/fai-backend/fai_backend/conversations/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/service.py
@@ -85,7 +85,7 @@ class ConversationService:
             conversation_id: UUID4,
             messages: list[Message]
     ) -> Conversation:
-        return await self.conversations_repo.update(str(conversation_id), {'messages': messages})
+        return await self.conversations_repo.update_id(str(conversation_id), {'messages': messages})
 
     async def update(self, conversation: Conversation) -> Conversation:
         return await self.conversations_repo.update(conversation)

--- a/fai-rag-app/fai-backend/fai_backend/conversations/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/service.py
@@ -1,12 +1,20 @@
-from pydantic import EmailStr
+from uuid import uuid4
 
-from fai_backend.conversations.models import Conversation
+from bson import ObjectId
+from pydantic import EmailStr, UUID4, ValidationError
+
+from fai_backend.conversations.models import Conversation, Message, Feedback
 from fai_backend.conversations.schema import (
     CreateConversationRequest,
     FeedbackResponse,
     ResponseMessage,
 )
+from fai_backend.conversations.utils import get_all_messages_in_conversation
+from fai_backend.logger.console import console
+from fai_backend.qaf.schema import SubmitAnswerPayload, GenerateAnswerPayload, QuestionFilterParams
 from fai_backend.repositories import ConversationRepository
+from fai_backend.repository.query.component import LogicalExpression, AttributeAssignment
+from fai_backend.schema import ProjectUser
 
 
 class ConversationService:
@@ -18,18 +26,53 @@ class ConversationService:
     async def create_conversation(
             self, user_email: EmailStr, conversation: CreateConversationRequest
     ) -> Conversation | None:
-        conversation = Conversation.model_validate({
-            **conversation.model_dump(exclude={'messages'}),
-            'messages': [{**message.model_dump(), 'user': user_email} for message in conversation.messages],
+        conversation_data = conversation.dict(by_alias=True)
+        conversation_data.update({
             'participants': [user_email],
-            'created_by': user_email,
-            'id': 'temp_id'
+            'created_by': user_email
         })
-        conversation.created_by = user_email
-        conversation.participants.append(user_email)
-        return Conversation.model_validate((await self.conversations_repo.create(
-            Conversation.model_validate(conversation.model_dump())
-        )).model_dump())
+
+        validated_conversation = Conversation(**conversation_data)
+
+        created_conversation = await self.conversations_repo.create(validated_conversation)
+        return created_conversation
+
+    async def add_message_to_conversation(
+            self,
+            project_user: ProjectUser,
+            payload: SubmitAnswerPayload | GenerateAnswerPayload,
+    ):
+        try:
+            conversation_copy = (await self.conversations_repo.get(payload.question_id)).model_copy()
+            conversation_messages = get_all_messages_in_conversation(conversation_copy)
+
+            {
+                'user': lambda: conversation_messages.append(
+                    Message(
+                        user='user',
+                        content=payload.answer,
+                        type='answer',
+                        created_by=project_user.email
+                    )
+                ),
+                'assistant': lambda: conversation_messages.append(
+                    Message(
+                        user='assistant',
+                        content=payload.answer,
+                        type='generated_answer',
+                        created_by=project_user.email
+                    )
+                )
+            }['assistant' if isinstance(payload, GenerateAnswerPayload) else 'user']()
+
+            result = await self.conversations_repo.update(
+                conversation_copy
+            )
+
+            return result
+
+        except Exception:
+            console.print_exception(show_locals=False)
 
     async def add_feedback(self, message, email, body) -> FeedbackResponse | None:
         pass
@@ -37,12 +80,77 @@ class ConversationService:
     async def add_message(self, param, email, body) -> list[ResponseMessage]:
         pass
 
+    async def update_messages(
+            self,
+            conversation_id: UUID4,
+            messages: list[Message]
+    ) -> Conversation:
+        return await self.conversations_repo.update(str(conversation_id), {'messages': messages})
+
+    async def update(self, conversation: Conversation) -> Conversation:
+        return await self.conversations_repo.update(conversation)
+
     async def get_conversation_by_id(
             self, conversation_id: str
     ) -> Conversation | None:
         conversation = await self.conversations_repo.get(conversation_id)
-        return Conversation.model_validate(conversation.model_dump()) if conversation else None
+
+        return Conversation.model_validate(conversation) if conversation else None
 
     async def list_conversations(self) -> list[Conversation]:
         return [Conversation.model_validate(conversation.model_dump()) for conversation in
                 await self.conversations_repo.list()]
+
+    async def list_and_sort_conversation(
+            self,
+            query: LogicalExpression,
+            sort_by: str,
+            sort_order: str
+    ) -> list[Conversation]:
+        return await self.conversations_repo.list(query=query, sort_by=sort_by, sort_order=sort_order)
+
+    async def filter_and_list_conversation(
+            self,
+            query: LogicalExpression,
+            query_params: QuestionFilterParams
+    ) -> list[Conversation]:
+        query_result = await self.conversations_repo.list(
+            query=query,
+            sort_by=query_params.sort,
+            sort_order=query_params.sort_order
+        )
+
+        return query_result
+
+    async def create_inactive_copy_of_conversation(
+            self,
+            conversation_id: str
+    ) -> Conversation:
+        conversation = await self.conversations_repo.get(conversation_id)
+
+        conversation_data = conversation.dict(by_alias=True)
+        conversation_data.update({
+            '_id': ObjectId(),
+            'conversation_id': uuid4(),
+            'conversation_root_id': conversation.conversation_id,
+        })
+        validated_conversation = Conversation(**conversation_data)
+
+        created_conversation = await self.conversations_repo.create(validated_conversation)
+        return created_conversation
+
+    async def set_active_conversation(
+            self,
+            conversation_id: str
+    ) -> Conversation:
+        new_active_conversation = await self.conversations_repo.get(conversation_id)
+
+        query = LogicalExpression('AND', [
+            AttributeAssignment('conversation_id', new_active_conversation.conversation_root_id),
+        ])
+        root_conversation = (await self.conversations_repo.list(query=query))[0]
+
+        root_conversation.conversation_active_id = new_active_conversation.conversation_id
+
+        updated_conversation = await self.conversations_repo.update(root_conversation)
+        return Conversation.model_validate(updated_conversation.model_dump())

--- a/fai-rag-app/fai-backend/fai_backend/conversations/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/service.py
@@ -28,7 +28,7 @@ class ConversationService:
         conversation.created_by = user_email
         conversation.participants.append(user_email)
         return Conversation.model_validate((await self.conversations_repo.create(
-            Conversation.model_validate(conversation.model_dump(exclude={'id'}))
+            Conversation.model_validate(conversation.model_dump())
         )).model_dump())
 
     async def add_feedback(self, message, email, body) -> FeedbackResponse | None:

--- a/fai-rag-app/fai-backend/fai_backend/conversations/utils.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/utils.py
@@ -1,0 +1,33 @@
+from fai_backend.conversations.models import Message, Conversation
+from fai_backend.repositories import ConversationRepository
+from fai_backend.repository.query.component import LogicalExpression, AttributeAssignment
+
+
+async def get_root_conversations_created_by_user(
+        conversation_repo: ConversationRepository,
+        user_email: str
+) -> list[Conversation]:
+    active_conversation_by_user = LogicalExpression('AND', [
+        AttributeAssignment('conversation_root_id', None),
+        AttributeAssignment('created_by', user_email)
+    ])
+
+    return await conversation_repo.list(active_conversation_by_user)
+
+
+def get_first_message_in_conversation(
+        conversation: Conversation
+) -> list[Message]:
+    return [conversation.messages[0]] if conversation.messages else []
+
+
+def get_last_message_in_conversation(
+        conversation: Conversation
+) -> list[Message]:
+    return [conversation.messages[-1]] if conversation.messages else []
+
+
+def get_all_messages_in_conversation(
+        conversation: Conversation
+) -> list[Message]:
+    return conversation.messages

--- a/fai-rag-app/fai-backend/fai_backend/projects/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/projects/service.py
@@ -24,7 +24,7 @@ class ProjectService:
 
     async def update_project(self, project_id: str, project: ProjectUpdateRequest):
         ignore_keys = ['id', 'timestamp']
-        return await self.repo.update(
+        return await self.repo.update_id(
             project_id,
             {
                 key: project.model_dump()[key]

--- a/fai-rag-app/fai-backend/fai_backend/qaf/dependencies.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/dependencies.py
@@ -1,5 +1,7 @@
 from fastapi import Depends
 
+from fai_backend.conversations.dependencies import get_conversation_service
+from fai_backend.conversations.service import ConversationService
 from fai_backend.dependencies import get_project_user
 from fai_backend.files.dependecies import get_file_upload_service
 from fai_backend.files.service import FileUploadService
@@ -54,10 +56,12 @@ async def question_details_loader(
 
 async def question_create_action(
         body: SubmitQuestionPayload,
-        service: QAFService = Depends(QAFService.factory),
+        qaf_service: QAFService = Depends(QAFService.factory),
+        conversation_service: ConversationService = Depends(get_conversation_service),
         user: ProjectUser = Depends(get_project_user),
 ) -> QuestionDetails:
-    question = await service.submit_question(
+    question = await qaf_service.submit_new_question(
+        conversation_service,
         user,
         body.question,
         body.model_dump(exclude={'question', 'tags'}),

--- a/fai-rag-app/fai-backend/fai_backend/qaf/schema.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/schema.py
@@ -8,6 +8,7 @@ from fai_backend.schema import Timestamp
 
 class QuestionEntry(BaseModel):
     id: str
+    type: str
     messages: list[ResponseMessage] = Field(default_factory=list, repr=False)
     metadata: dict = Field(default_factory=dict, repr=False)
     tags: list[str] = Field(default_factory=list)

--- a/fai-rag-app/fai-backend/fai_backend/qaf/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/service.py
@@ -41,7 +41,6 @@ class QAFService:
             tags: list[str] | None = None,
     ) -> QuestionDetails:
         conversation_request = CreateConversationRequest(
-            # id=project_user.project_id,
             type='question',
             messages=[
                 CreateMessageRequest(

--- a/fai-rag-app/fai-backend/fai_backend/qaf/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/service.py
@@ -3,7 +3,8 @@ from typing import Literal
 from pydantic import BaseModel, computed_field
 
 from fai_backend.conversations.models import Conversation, Feedback, Message
-from fai_backend.conversations.schema import ResponseMessage, CreateConversationRequest, CreateMessageRequest
+from fai_backend.conversations.schema import ResponseMessage, CreateConversationRequest, CreateMessageRequest, \
+    CreateThreadRequest
 from fai_backend.conversations.service import ConversationService
 from fai_backend.logger.console import console
 from fai_backend.qaf.schema import (
@@ -44,6 +45,20 @@ class QAFService:
             project_user.email,
             CreateConversationRequest(
                 project_id=project_user.project_id,
+                threads=[
+                    CreateThreadRequest(
+                        thread_name='initial thread',
+                        active_flag=True,
+                        messages=[
+                            CreateMessageRequest(
+                                user='user',
+                                created_by=project_user.email,
+                                content=question,
+                                type='question'
+                            )
+                        ]
+                    )
+                ],
                 messages=[
                     CreateMessageRequest(
                         user='user',

--- a/fai-rag-app/fai-backend/fai_backend/qaf/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/service.py
@@ -3,7 +3,8 @@ from typing import Literal
 from pydantic import BaseModel, computed_field
 
 from fai_backend.conversations.models import Conversation, Feedback, Message
-from fai_backend.conversations.schema import ResponseMessage
+from fai_backend.conversations.schema import ResponseMessage, CreateConversationRequest, CreateMessageRequest
+from fai_backend.conversations.service import ConversationService
 from fai_backend.logger.console import console
 from fai_backend.qaf.schema import (
     ApproveAnswerPayload,
@@ -31,21 +32,20 @@ class QAFService:
     def __init__(self, conversations: ConversationRepository):
         self.conversations = conversations
 
-    async def submit_question(
+    async def submit_new_question(
             self,
+            conversation_service: ConversationService,
             project_user: ProjectUser,
             question: str,
             meta: dict,
             tags: list[str] | None = None,
     ) -> QuestionDetails:
-        conversation = await self.conversations.create(
-            Conversation(
-                id='temp_id',
-                created_by=project_user.email,
-                participants=[project_user.email],
-                type='question',
+        conversation = await conversation_service.create_conversation(
+            project_user.email,
+            CreateConversationRequest(
+                project_id=project_user.project_id,
                 messages=[
-                    Message(
+                    CreateMessageRequest(
                         user='user',
                         created_by=project_user.email,
                         content=question,

--- a/fai-rag-app/fai-backend/fai_backend/repository/composite.py
+++ b/fai-rag-app/fai-backend/fai_backend/repository/composite.py
@@ -1,6 +1,7 @@
 from typing import Generic, TypeVar
 
 from fai_backend.repository.interface import IAsyncRepo
+from fai_backend.repository.query.component import QueryComponent
 
 T = TypeVar('T')
 
@@ -16,7 +17,7 @@ class CompositeRepo(Generic[T], IAsyncRepo[T]):
                 return item
         return None
 
-    async def list(self) -> list[T]:
+    async def list(self, query: QueryComponent = None, sort_by: str = None, sort_order: str = 'asc') -> list[T]:
         all_items = []
         for repo in self._repos:
             items = await repo.list()
@@ -34,7 +35,7 @@ class CompositeRepo(Generic[T], IAsyncRepo[T]):
     async def update_id(self, item_id: str, item: dict) -> T | None:
         for repo in self._repos:
             try:
-                updated_item = await repo.update(item_id, item)
+                updated_item = await repo.update_id(item_id, item)
                 if updated_item is not None:
                     return updated_item
             except NotImplementedError:

--- a/fai-rag-app/fai-backend/fai_backend/repository/composite.py
+++ b/fai-rag-app/fai-backend/fai_backend/repository/composite.py
@@ -32,6 +32,14 @@ class CompositeRepo(Generic[T], IAsyncRepo[T]):
                 continue
         return None
 
+    async def update(self, item: T) -> T | None:
+        for repo in self._repos:
+            try:
+                return await repo.update(item)
+            except NotImplementedError:
+                continue
+        return None
+
     async def update_id(self, item_id: str, item: dict) -> T | None:
         for repo in self._repos:
             try:

--- a/fai-rag-app/fai-backend/fai_backend/repository/composite.py
+++ b/fai-rag-app/fai-backend/fai_backend/repository/composite.py
@@ -31,7 +31,7 @@ class CompositeRepo(Generic[T], IAsyncRepo[T]):
                 continue
         return None
 
-    async def update(self, item_id: str, item: dict) -> T | None:
+    async def update_id(self, item_id: str, item: dict) -> T | None:
         for repo in self._repos:
             try:
                 updated_item = await repo.update(item_id, item)

--- a/fai-rag-app/fai-backend/fai_backend/repository/interface.py
+++ b/fai-rag-app/fai-backend/fai_backend/repository/interface.py
@@ -15,8 +15,11 @@ class IAsyncRepo(Protocol[T]):
     async def create(self, item: T) -> T | None:
         raise NotImplementedError('create not implemented')
 
-    async def update(self, item_id: str, item: dict) -> T | None:
+    async def update(self, item: T) -> T | None:
         raise NotImplementedError('update not implemented')
+
+    async def update_id(self, item_id: str, item: dict) -> T | None:
+        raise NotImplementedError('update_id not implemented')
 
     async def delete(self, item_id: str) -> T | None:
         raise NotImplementedError('delete not implemented')

--- a/fai-rag-app/fai-backend/fai_backend/repository/memory.py
+++ b/fai-rag-app/fai-backend/fai_backend/repository/memory.py
@@ -1,6 +1,7 @@
 from typing import Generic, TypeVar
 
 from fai_backend.repository.interface import IAsyncRepo
+from fai_backend.repository.query.component import QueryComponent
 
 T = TypeVar('T')
 
@@ -19,10 +20,10 @@ class InMemoryRepo(Generic[T], IAsyncRepo[T]):
     async def get(self, item_id: str) -> T | None:
         return self._items.get(int(item_id))
 
-    async def list(self) -> list[T]:
+    async def list(self, query: QueryComponent = None, sort_by: str = None, sort_order: str = 'asc') -> list[T]:
         return list(self._items.values())
 
-    async def update(self, item_id: str, item_data: dict) -> T | None:
+    async def update_id(self, item_id: str, item_data: dict) -> T | None:
         if int(item_id) in self._items:
             item = self._items[int(item_id)]
             for key, value in item_data.items():

--- a/fai-rag-app/fai-backend/fai_backend/repository/memory.py
+++ b/fai-rag-app/fai-backend/fai_backend/repository/memory.py
@@ -23,6 +23,12 @@ class InMemoryRepo(Generic[T], IAsyncRepo[T]):
     async def list(self, query: QueryComponent = None, sort_by: str = None, sort_order: str = 'asc') -> list[T]:
         return list(self._items.values())
 
+    async def update(self, item: T) -> T | None:
+        if int(item.id) in self._items:
+            self._items[int(item.id)] = item
+            return item
+        return
+
     async def update_id(self, item_id: str, item_data: dict) -> T | None:
         if int(item_id) in self._items:
             item = self._items[int(item_id)]

--- a/fai-rag-app/fai-backend/tests/conversations/test_conversation_service.py
+++ b/fai-rag-app/fai-backend/tests/conversations/test_conversation_service.py
@@ -1,11 +1,10 @@
 from tests.conversations.test_fixtures import *
-from fai_backend.qaf.schema import QuestionFilterParams, GenerateAnswerPayload
+from fai_backend.qaf.schema import QuestionFilterParams
 from fai_backend.repository.query.component import LogicalExpression, AttributeAssignment
 
 
 @pytest.mark.asyncio
 async def test_create_conversation(
-        setup_db,
         conversation_service,
         project_admin_user,
         create_dark_matter_question
@@ -24,7 +23,6 @@ async def test_create_conversation(
 
 @pytest.mark.asyncio
 async def test_filter_and_list_conversation(
-        setup_db,
         conversation_service,
         project_admin_user,
         create_dark_matter_question
@@ -53,7 +51,6 @@ async def test_filter_and_list_conversation(
 
 @pytest.mark.asyncio
 async def test_create_inactive_copy_of_conversation(
-        setup_db,
         conversation_service,
         project_admin_user,
         create_dark_matter_question
@@ -79,7 +76,6 @@ async def test_create_inactive_copy_of_conversation(
 
 @pytest.mark.asyncio
 async def test_set_active_conversation(
-        setup_db,
         conversation_service,
         project_admin_user,
         create_dark_matter_question

--- a/fai-rag-app/fai-backend/tests/conversations/test_conversation_service.py
+++ b/fai-rag-app/fai-backend/tests/conversations/test_conversation_service.py
@@ -1,0 +1,101 @@
+from tests.conversations.test_fixtures import *
+from fai_backend.qaf.schema import QuestionFilterParams, GenerateAnswerPayload
+from fai_backend.repository.query.component import LogicalExpression, AttributeAssignment
+
+
+@pytest.mark.asyncio
+async def test_create_conversation(
+        setup_db,
+        conversation_service,
+        project_admin_user,
+        create_dark_matter_question
+):
+    dark_matter_conversation = await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    assert dark_matter_conversation is not None, "No conversation returned"
+    assert dark_matter_conversation.messages[0].content == DARK_MATTER_QUESTION, "Incorrect question content"
+    assert dark_matter_conversation.conversation_root_id is None, "Conversation root id should be None"
+    assert dark_matter_conversation.conversation_active_id == dark_matter_conversation.conversation_id, \
+        "Conversation root id and active id are not the same"
+
+
+@pytest.mark.asyncio
+async def test_filter_and_list_conversation(
+        setup_db,
+        conversation_service,
+        project_admin_user,
+        create_dark_matter_question
+):
+    await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    query = LogicalExpression('AND', [
+        AttributeAssignment('type', 'question'),
+        AttributeAssignment('created_by', project_admin_user.email)
+    ])
+
+    empty_query_params = QuestionFilterParams()
+
+    filter_result = await conversation_service.filter_and_list_conversation(
+        query,
+        query_params=empty_query_params
+    )
+
+    assert filter_result is not None, "No conversation returned"
+    assert len(filter_result) == 1, "Incorrect number of conversations returned"
+    assert filter_result[0].messages[0].content == DARK_MATTER_QUESTION, "Incorrect question content"
+
+
+@pytest.mark.asyncio
+async def test_create_inactive_copy_of_conversation(
+        setup_db,
+        conversation_service,
+        project_admin_user,
+        create_dark_matter_question
+):
+    dark_matter_conversation = await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    dark_matter_conversation_copy = await conversation_service.create_inactive_copy_of_conversation(
+        dark_matter_conversation.id
+    )
+
+    assert dark_matter_conversation_copy is not None, "No conversation suggestion returned"
+    assert dark_matter_conversation_copy.id != dark_matter_conversation.id, \
+        "ID should be unique and not copied from original"
+    assert dark_matter_conversation_copy.conversation_id != dark_matter_conversation.conversation_id, \
+        "Conversation ID should be unique and not copied from original conversation"
+    assert dark_matter_conversation_copy.conversation_root_id == dark_matter_conversation.conversation_id, \
+        "Root ID should point to original conversation"
+    assert dark_matter_conversation_copy.messages[0].content == DARK_MATTER_QUESTION, "Incorrect question content"
+
+
+@pytest.mark.asyncio
+async def test_set_active_conversation(
+        setup_db,
+        conversation_service,
+        project_admin_user,
+        create_dark_matter_question
+):
+    dark_matter_conversation = await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    dark_matter_copy = await conversation_service.create_inactive_copy_of_conversation(
+        dark_matter_conversation.id
+    )
+
+    root_conversation_updated = await conversation_service.set_active_conversation(dark_matter_copy.id)
+
+    assert root_conversation_updated.conversation_root_id is None, "Root ID should be None"
+    assert root_conversation_updated.conversation_active_id == dark_matter_copy.conversation_id, \
+        "Active ID should point to dark_matter_copy"
+

--- a/fai-rag-app/fai-backend/tests/conversations/test_fixtures.py
+++ b/fai-rag-app/fai-backend/tests/conversations/test_fixtures.py
@@ -1,0 +1,91 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from beanie import init_beanie
+from bson import ObjectId
+from mongomock_motor import AsyncMongoMockClient
+
+from fai_backend.conversations.schema import CreateConversationRequest, CreateMessageRequest
+from fai_backend.conversations.service import ConversationService
+from fai_backend.repositories import conversation_repo, ProjectModel, PinCodeModel, ConversationDocument
+from fai_backend.schema import ProjectUser
+
+TEST_USER_EMAIL = "user@example.com"
+DARK_MATTER_QUESTION = "What is dark matter?"
+DARK_MATTER_ANSWER = ("Dark matter is a form of matter thought to account for approximately 85% of the matter in the "
+                      "universe.")
+MEANING_OF_LIFE_QUESTION = "What is the meaning of life?"
+
+
+@pytest_asyncio.fixture
+async def conversation_service():
+    return ConversationService(conversation_repo=conversation_repo)
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    client = AsyncMongoMockClient().test_db
+    await init_beanie(
+        database=client,
+        document_models=[ProjectModel, PinCodeModel, ConversationDocument]
+    )
+
+
+@pytest.fixture
+def project_admin_user():
+    return ProjectUser(
+        email=TEST_USER_EMAIL,
+        permissions={"can_ask_questions": True},
+        project_id="123",
+        role="admin"
+    )
+
+
+@pytest.fixture
+def create_dark_matter_question(project_admin_user):
+    question = DARK_MATTER_QUESTION
+    question_meta = {
+        "errand_id": "sk-123",
+        "subject": "Physics"
+    }
+    question_tag = ["physics"]
+
+    return CreateConversationRequest(
+        id=ObjectId(),
+        type='question',
+        messages=[
+            CreateMessageRequest(
+                user='user',
+                created_by=project_admin_user.email,
+                content=question,
+                type='question'
+            )
+        ],
+        metadata=question_meta,
+        tags=question_tag
+    )
+
+
+@pytest.fixture
+def create_meaning_of_life_question(project_admin_user):
+    question = MEANING_OF_LIFE_QUESTION
+    question_meta = {
+        "errand_id": "sk-456",
+        "subject": "Philosophy"
+    }
+    question_tag = ["philosophy"]
+
+    return CreateConversationRequest(
+        type='question',
+        messages=[
+            CreateMessageRequest(
+                user='user',
+                created_by=project_admin_user.email,
+                content=question,
+                type='question'
+            )
+        ],
+        metadata=question_meta,
+        tags=question_tag
+    )

--- a/fai-rag-app/fai-backend/tests/conversations/test_utils.py
+++ b/fai-rag-app/fai-backend/tests/conversations/test_utils.py
@@ -5,9 +5,8 @@ from fai_backend.conversations.utils import *
 @pytest.mark.asyncio
 async def test_get_active_conversations_when_no_conversation_created_by_user_then_expect_no_conversations(
         conversation_service,
-        setup_db,
-        project_admin_user,
-        create_dark_matter_question,
+        conversation_repo,
+        project_admin_user
 ):
     active_conversations = await get_root_conversations_created_by_user(
         conversation_repo,
@@ -21,7 +20,7 @@ async def test_get_active_conversations_when_no_conversation_created_by_user_the
 @pytest.mark.asyncio
 async def test_create_one_active_conversation_then_expect_one_active_conversation_created(
         conversation_service,
-        setup_db,
+        conversation_repo,
         project_admin_user,
         create_dark_matter_question,
 ):
@@ -44,7 +43,7 @@ async def test_create_one_active_conversation_then_expect_one_active_conversatio
 @pytest.mark.asyncio
 async def test_create_two_active_conversation_then_expect_two_active_conversation_created(
         conversation_service,
-        setup_db,
+        conversation_repo,
         project_admin_user,
         create_dark_matter_question,
         create_meaning_of_life_question
@@ -79,7 +78,6 @@ async def test_create_two_active_conversation_then_expect_two_active_conversatio
 @pytest.mark.asyncio
 async def test_get_first_message_in_conversation_with_no_messages_then_expect_empty_list(
         conversation_service,
-        setup_db,
         project_admin_user,
         create_dark_matter_question
 ):
@@ -103,7 +101,6 @@ async def test_get_first_message_in_conversation_with_no_messages_then_expect_em
 @pytest.mark.asyncio
 async def test_get_first_message_in_conversation(
         conversation_service,
-        setup_db,
         project_admin_user,
         create_dark_matter_question
 ):
@@ -121,7 +118,6 @@ async def test_get_first_message_in_conversation(
 @pytest.mark.asyncio
 async def test_get_last_message_in_conversation(
         conversation_service,
-        setup_db,
         project_admin_user,
         create_dark_matter_question
 ):
@@ -139,7 +135,6 @@ async def test_get_last_message_in_conversation(
 @pytest.mark.asyncio
 async def test_get_all_messages_in_conversation(
         conversation_service,
-        setup_db,
         project_admin_user,
         create_dark_matter_question,
         create_meaning_of_life_question

--- a/fai-rag-app/fai-backend/tests/conversations/test_utils.py
+++ b/fai-rag-app/fai-backend/tests/conversations/test_utils.py
@@ -1,0 +1,158 @@
+from tests.conversations.test_fixtures import *
+from fai_backend.conversations.utils import *
+
+
+@pytest.mark.asyncio
+async def test_get_active_conversations_when_no_conversation_created_by_user_then_expect_no_conversations(
+        conversation_service,
+        setup_db,
+        project_admin_user,
+        create_dark_matter_question,
+):
+    active_conversations = await get_root_conversations_created_by_user(
+        conversation_repo,
+        project_admin_user.email
+    )
+
+    assert active_conversations is not None
+    assert len(active_conversations) == 0
+
+
+@pytest.mark.asyncio
+async def test_create_one_active_conversation_then_expect_one_active_conversation_created(
+        conversation_service,
+        setup_db,
+        project_admin_user,
+        create_dark_matter_question,
+):
+    await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    active_conversations = await get_root_conversations_created_by_user(
+        conversation_repo,
+        project_admin_user.email
+    )
+
+    assert active_conversations is not None
+    assert len(active_conversations) == 1
+    assert active_conversations[0].created_by == project_admin_user.email
+    assert active_conversations[0].messages[0].content == DARK_MATTER_QUESTION
+
+
+@pytest.mark.asyncio
+async def test_create_two_active_conversation_then_expect_two_active_conversation_created(
+        conversation_service,
+        setup_db,
+        project_admin_user,
+        create_dark_matter_question,
+        create_meaning_of_life_question
+):
+    await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_meaning_of_life_question
+    )
+
+    active_conversations = await get_root_conversations_created_by_user(
+        conversation_repo,
+        project_admin_user.email
+    )
+
+    assert active_conversations is not None
+    assert len(active_conversations) == 2
+
+    questions_in_conversations = [conversation.messages[0].content for conversation in active_conversations]
+    assert DARK_MATTER_QUESTION, MEANING_OF_LIFE_QUESTION in questions_in_conversations
+
+    assert active_conversations[0].conversation_root_id is None
+    assert active_conversations[1].conversation_root_id is None
+    assert active_conversations[0].conversation_id == active_conversations[0].conversation_active_id
+    assert active_conversations[1].conversation_id == active_conversations[1].conversation_active_id
+
+
+@pytest.mark.asyncio
+async def test_get_first_message_in_conversation_with_no_messages_then_expect_empty_list(
+        conversation_service,
+        setup_db,
+        project_admin_user,
+        create_dark_matter_question
+):
+
+    conversation = CreateConversationRequest(
+        type='question',
+        messages=[],
+    )
+
+    conversation = await conversation_service.create_conversation(
+        project_admin_user.email,
+        conversation
+    )
+
+    first_message = get_first_message_in_conversation(conversation)
+
+    assert first_message is not None
+    assert first_message == []
+
+
+@pytest.mark.asyncio
+async def test_get_first_message_in_conversation(
+        conversation_service,
+        setup_db,
+        project_admin_user,
+        create_dark_matter_question
+):
+    conversation = await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    first_message = get_first_message_in_conversation(conversation)
+
+    assert first_message is not None
+    assert len(first_message) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_last_message_in_conversation(
+        conversation_service,
+        setup_db,
+        project_admin_user,
+        create_dark_matter_question
+):
+    conversation = await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    last_message = get_last_message_in_conversation(conversation)
+
+    assert last_message is not None
+    assert last_message[0].content == DARK_MATTER_QUESTION
+
+
+@pytest.mark.asyncio
+async def test_get_all_messages_in_conversation(
+        conversation_service,
+        setup_db,
+        project_admin_user,
+        create_dark_matter_question,
+        create_meaning_of_life_question
+):
+    conversation = await conversation_service.create_conversation(
+        project_admin_user.email,
+        create_dark_matter_question
+    )
+
+    all_messages = get_all_messages_in_conversation(conversation)
+
+    assert all_messages is not None
+    assert len(all_messages) == 1
+    assert all_messages[0].content == DARK_MATTER_QUESTION
+    assert all_messages[0].created_by == project_admin_user.email
+    assert all_messages[0].type == 'question'

--- a/fai-rag-app/fai-backend/tests/qaf/test_qaf_service.py
+++ b/fai-rag-app/fai-backend/tests/qaf/test_qaf_service.py
@@ -1,37 +1,7 @@
-import uuid
-
-import pytest
-import pytest_asyncio
-from beanie import init_beanie
-from mongomock_motor import AsyncMongoMockClient
-
-from fai_backend.conversations.service import ConversationService
+from tests.conversations.test_fixtures import *
 from fai_backend.conversations.utils import get_all_messages_in_conversation
 from fai_backend.qaf.schema import GenerateAnswerPayload, QuestionFilterParams, ApproveAnswerPayload
 from fai_backend.qaf.service import QAFService
-from fai_backend.repositories import conversation_repo, ProjectModel, PinCodeModel, ConversationDocument
-from fai_backend.schema import ProjectUser
-
-TEST_USER_EMAIL = "user@example.com"
-
-
-@pytest_asyncio.fixture
-async def setup_db():
-    client = AsyncMongoMockClient().test_db
-    await init_beanie(
-        database=client,
-        document_models=[ProjectModel, PinCodeModel, ConversationDocument]
-    )
-
-
-@pytest.fixture
-def project_admin_user():
-    return ProjectUser(
-        email=TEST_USER_EMAIL,
-        permissions={"can_ask_questions": True},
-        project_id=str(uuid.uuid4()),
-        role="admin"
-    )
 
 
 @pytest_asyncio.fixture
@@ -39,17 +9,11 @@ async def qaf_service():
     return QAFService()
 
 
-@pytest_asyncio.fixture
-async def conversation_service():
-    return ConversationService(conversation_repo=conversation_repo)
-
-
 @pytest.mark.asyncio
 async def test_submit_new_question_then_expect_new_conversation_returned(
-        setup_db,
         qaf_service,
-        project_admin_user,
-        conversation_service
+        conversation_service,
+        project_admin_user
 ):
     question = "What is the meaning of life?"
     question_meta = {
@@ -76,7 +40,6 @@ async def test_submit_new_question_then_expect_new_conversation_returned(
 
 @pytest.mark.asyncio
 async def test_add_answer_to_question_then_expect_answer_added(
-        setup_db,
         qaf_service,
         conversation_service,
         project_admin_user
@@ -113,7 +76,6 @@ async def test_add_answer_to_question_then_expect_answer_added(
 
 @pytest.mark.asyncio
 async def test_list_submitted_questions_when_no_questions_exist_then_expect_empty_list_returned(
-        setup_db,
         qaf_service,
         conversation_service,
         project_admin_user
@@ -128,7 +90,6 @@ async def test_list_submitted_questions_when_no_questions_exist_then_expect_empt
 
 @pytest.mark.asyncio
 async def test_list_submitted_questions_when_questions_exist_then_expect_questions_returned(
-        setup_db,
         qaf_service,
         conversation_service,
         project_admin_user
@@ -162,7 +123,6 @@ async def test_list_submitted_questions_when_questions_exist_then_expect_questio
 
 @pytest.mark.asyncio
 async def test_get_submitted_question_details_then_expect_question_returned(
-        setup_db,
         qaf_service,
         conversation_service,
         project_admin_user
@@ -197,7 +157,6 @@ async def test_get_submitted_question_details_then_expect_question_returned(
 
 @pytest.mark.asyncio
 async def test_submit_new_question_then_expect_active_thread_created_containing_question(
-        setup_db,
         qaf_service,
         project_admin_user,
         conversation_service
@@ -228,7 +187,6 @@ async def test_submit_new_question_then_expect_active_thread_created_containing_
 
 @pytest.mark.asyncio
 async def test_add_feedback_to_answer_then_expect_feedback_added(
-        setup_db,
         qaf_service,
         conversation_service,
         project_admin_user

--- a/fai-rag-app/fai-backend/tests/qaf/test_qaf_service.py
+++ b/fai-rag-app/fai-backend/tests/qaf/test_qaf_service.py
@@ -1,0 +1,282 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from beanie import init_beanie
+from mongomock_motor import AsyncMongoMockClient
+
+from fai_backend.conversations.service import ConversationService
+from fai_backend.conversations.utils import get_all_messages_in_conversation
+from fai_backend.qaf.schema import GenerateAnswerPayload, QuestionFilterParams, ApproveAnswerPayload
+from fai_backend.qaf.service import QAFService
+from fai_backend.repositories import conversation_repo, ProjectModel, PinCodeModel, ConversationDocument
+from fai_backend.schema import ProjectUser
+
+TEST_USER_EMAIL = "user@example.com"
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    client = AsyncMongoMockClient().test_db
+    await init_beanie(
+        database=client,
+        document_models=[ProjectModel, PinCodeModel, ConversationDocument]
+    )
+
+
+@pytest.fixture
+def project_admin_user():
+    return ProjectUser(
+        email=TEST_USER_EMAIL,
+        permissions={"can_ask_questions": True},
+        project_id=str(uuid.uuid4()),
+        role="admin"
+    )
+
+
+@pytest_asyncio.fixture
+async def qaf_service():
+    return QAFService()
+
+
+@pytest_asyncio.fixture
+async def conversation_service():
+    return ConversationService(conversation_repo=conversation_repo)
+
+
+@pytest.mark.asyncio
+async def test_submit_new_question_then_expect_new_conversation_returned(
+        setup_db,
+        qaf_service,
+        project_admin_user,
+        conversation_service
+):
+    question = "What is the meaning of life?"
+    question_meta = {
+        "errand_id": "sk-123",
+        "subject": "Life"
+    }
+    question_tag = ["philosophy"]
+
+    submit_question_result = await qaf_service.submit_new_question(
+        conversation_service,
+        project_admin_user,
+        question,
+        question_meta,
+        question_tag
+    )
+
+    assert submit_question_result is not None, "No question returned"
+    assert submit_question_result.type == "question", "Incorrect question type"
+    assert submit_question_result.question.content == question, "Incorrect question in question content"
+    assert submit_question_result.errand_id == question_meta["errand_id"], "Incorrect errand_id in question errand_id"
+    assert submit_question_result.subject == question_meta["subject"], "Incorrect subject in question subject"
+    assert submit_question_result.tags == question_tag, "Incorrect tags in question tags"
+
+
+@pytest.mark.asyncio
+async def test_add_answer_to_question_then_expect_answer_added(
+        setup_db,
+        qaf_service,
+        conversation_service,
+        project_admin_user
+):
+    question = "What is the answer to life, the universe, and everything?"
+    question_meta = {
+        "errand_id": "sk-123",
+        "subject": "Life"
+    }
+    question_tag = ["philosophy"]
+
+    submit_question_result = await qaf_service.submit_new_question(
+        conversation_service,
+        project_admin_user,
+        question,
+        question_meta,
+        question_tag
+    )
+
+    payload = GenerateAnswerPayload(
+        question_id=submit_question_result.id,
+        answer="42",
+    )
+
+    add_message_result = await qaf_service.add_message(
+        project_admin_user,
+        payload,
+        conversation_service
+    )
+
+    assert add_message_result is not None, "No question returned"
+    assert add_message_result.messages[1].content == payload.answer, "Incorrect answer in question messages"
+
+
+@pytest.mark.asyncio
+async def test_list_submitted_questions_when_no_questions_exist_then_expect_empty_list_returned(
+        setup_db,
+        qaf_service,
+        conversation_service,
+        project_admin_user
+):
+    empty_filter_params = QuestionFilterParams()
+
+    questions = await qaf_service.list_submitted_questions(project_admin_user, empty_filter_params,
+                                                           conversation_service)
+
+    assert len(questions) == 0, "Questions list is not empty"
+
+
+@pytest.mark.asyncio
+async def test_list_submitted_questions_when_questions_exist_then_expect_questions_returned(
+        setup_db,
+        qaf_service,
+        conversation_service,
+        project_admin_user
+):
+    question = "How does gravity work?"
+    question_meta = {
+        "errand_id": "sk-123",
+        "subject": "Physics"
+    }
+    question_tag = ["science"]
+
+    await qaf_service.submit_new_question(
+        conversation_service,
+        project_admin_user,
+        question,
+        question_meta,
+        question_tag
+    )
+
+    empty_filter_params = QuestionFilterParams()
+
+    questions = await qaf_service.list_submitted_questions(project_admin_user, empty_filter_params,
+                                                           conversation_service)
+
+    assert len(questions) == 1, "Questions list is empty"
+    assert questions[0].question.content == question, "Incorrect question in question content"
+    assert questions[0].errand_id == question_meta["errand_id"], "Incorrect errand_id in question errand_id"
+    assert questions[0].subject == question_meta["subject"], "Incorrect subject in question subject"
+    assert questions[0].tags == question_tag, "Incorrect tags in question tags"
+
+
+@pytest.mark.asyncio
+async def test_get_submitted_question_details_then_expect_question_returned(
+        setup_db,
+        qaf_service,
+        conversation_service,
+        project_admin_user
+):
+    question = "What is the speed of light?"
+    question_meta = {
+        "errand_id": "sk-123",
+        "subject": "Physics"
+    }
+    question_tag = ["science"]
+
+    submit_question_result = await qaf_service.submit_new_question(
+        conversation_service,
+        project_admin_user,
+        question,
+        question_meta,
+        question_tag
+    )
+
+    question_details = await qaf_service.submitted_question_details(
+        project_admin_user,
+        submit_question_result.id,
+        conversation_service
+    )
+
+    assert question_details is not None, "No question returned"
+    assert question_details.question.content == question, "Incorrect question in question content"
+    assert question_details.errand_id == question_meta["errand_id"], "Incorrect errand_id in question errand_id"
+    assert question_details.subject == question_meta["subject"], "Incorrect subject in question subject"
+    assert question_details.tags == question_tag, "Incorrect tags in question tags"
+
+
+@pytest.mark.asyncio
+async def test_submit_new_question_then_expect_active_thread_created_containing_question(
+        setup_db,
+        qaf_service,
+        project_admin_user,
+        conversation_service
+):
+    question = "What is the meaning of life?"
+    question_meta = {
+        "errand_id": "sk-123",
+        "subject": "Life"
+    }
+    question_tag = ["philosophy"]
+
+    submit_result = await qaf_service.submit_new_question(
+        conversation_service,
+        project_admin_user,
+        question,
+        question_meta,
+        question_tag
+    )
+
+    submitted_conversation = await conversation_service.get_conversation_by_id(submit_result.id)
+    active_thread = get_all_messages_in_conversation(submitted_conversation)
+
+    assert len(active_thread) == 1, "Incorrect number of messages in active thread"
+    assert active_thread[0].content == question, "Incorrect question in active thread"
+    assert active_thread[0].type == "question", "Incorrect type in active thread"
+    assert active_thread[0].created_by == project_admin_user.email, "Incorrect created_by in active thread"
+
+
+@pytest.mark.asyncio
+async def test_add_feedback_to_answer_then_expect_feedback_added(
+        setup_db,
+        qaf_service,
+        conversation_service,
+        project_admin_user
+):
+    question = "What is the answer to life, the universe, and everything?"
+    question_meta = {
+        "errand_id": "sk-123",
+        "subject": "Life"
+    }
+    question_tag = ["philosophy"]
+
+    submit_question_result = await qaf_service.submit_new_question(
+        conversation_service,
+        project_admin_user,
+        question,
+        question_meta,
+        question_tag
+    )
+
+    answer = "42"
+    answer_payload = GenerateAnswerPayload(
+        question_id=submit_question_result.id,
+        answer=answer,
+    )
+
+    await qaf_service.add_message(
+        project_admin_user,
+        answer_payload,
+        conversation_service
+    )
+
+    payload = ApproveAnswerPayload(
+        question_id=submit_question_result.id,
+        rating='approved',
+    )
+
+    add_feedback_result = await qaf_service.add_feedback(
+        project_admin_user,
+        payload,
+        submit_question_result.id,
+        conversation_service
+    )
+
+    assert add_feedback_result is not None, "No question returned"
+    assert add_feedback_result.question.content == question, "Incorrect question in question content"
+    assert add_feedback_result.errand_id == question_meta["errand_id"], "Incorrect errand_id in question errand_id"
+    assert add_feedback_result.subject == question_meta["subject"], "Incorrect subject in question subject"
+    assert add_feedback_result.tags == question_tag, "Incorrect tags in question tags"
+    assert len(add_feedback_result.messages) == 2, "Incorrect number of messages in question messages"
+    assert add_feedback_result.messages[1].feedback[
+               0].rating == payload.rating, "Incorrect rating in feedback"

--- a/fai-rag-app/fai-backend/tests/repository/test_composite.py
+++ b/fai-rag-app/fai-backend/tests/repository/test_composite.py
@@ -55,7 +55,7 @@ async def test_composite_list_items(composite_repo, items_to_create):
 async def test_composite_update_item(composite_repo, item, updated_data):
     created_item = await composite_repo.create(item)
 
-    updated_item = await composite_repo.update(created_item.id, updated_data)
+    updated_item = await composite_repo.update_id(created_item.id, updated_data)
     assert updated_item.name == 'NewItem'
     assert updated_item.value == 20
 
@@ -78,7 +78,7 @@ async def test_composite_non_existent_item(composite_repo, non_existent_id):
     retrieved_item = await composite_repo.get(non_existent_id)
     assert retrieved_item is None
 
-    updated_item = await composite_repo.update(non_existent_id, {'name': 'NoItem'})
+    updated_item = await composite_repo.update_id(non_existent_id, {'name': 'NoItem'})
     assert updated_item is None
 
     deleted_item = await composite_repo.delete(non_existent_id)

--- a/fai-rag-app/fai-backend/tests/repository/test_composite.py
+++ b/fai-rag-app/fai-backend/tests/repository/test_composite.py
@@ -52,7 +52,19 @@ async def test_composite_list_items(composite_repo, items_to_create):
     [(Item(name='OldItem', value=15), {'name': 'NewItem', 'value': 20})],
 )
 @pytest.mark.asyncio
-async def test_composite_update_item(composite_repo, item, updated_data):
+async def test_composite_update_item_by_object(composite_repo, item, updated_data):
+    created_item = await composite_repo.create(item)
+
+    created_item.name = updated_data.get('name')
+    created_item.value = updated_data.get('value')
+
+    updated_item = await composite_repo.update(created_item)
+    assert updated_item.name == updated_data.get('name')
+    assert updated_item.value == updated_data.get('value')
+
+
+@pytest.mark.asyncio
+async def test_composite_update_item_by_id(composite_repo, item, updated_data):
     created_item = await composite_repo.create(item)
 
     updated_item = await composite_repo.update_id(created_item.id, updated_data)

--- a/fai-rag-app/fai-backend/tests/repository/test_composite.py
+++ b/fai-rag-app/fai-backend/tests/repository/test_composite.py
@@ -63,6 +63,10 @@ async def test_composite_update_item_by_object(composite_repo, item, updated_dat
     assert updated_item.value == updated_data.get('value')
 
 
+@pytest.mark.parametrize(
+    'item, updated_data',
+    [(Item(name='OldItem', value=15), {'name': 'NewItem', 'value': 20})],
+)
 @pytest.mark.asyncio
 async def test_composite_update_item_by_id(composite_repo, item, updated_data):
     created_item = await composite_repo.create(item)

--- a/fai-rag-app/fai-backend/tests/repository/test_memory.py
+++ b/fai-rag-app/fai-backend/tests/repository/test_memory.py
@@ -49,7 +49,7 @@ async def test_list_items(repo, items_to_create):
 async def test_update_item(repo, item, updated_data):
     created_item = await repo.create(item)
 
-    updated_item = await repo.update(created_item.id, updated_data)
+    updated_item = await repo.update_id(created_item.id, updated_data)
     assert updated_item.name == 'NewItem'
     assert updated_item.value == 20
 
@@ -72,7 +72,7 @@ async def test_non_existent_item(repo, non_existent_id):
     retrieved_item = await repo.get(non_existent_id)
     assert retrieved_item is None
 
-    updated_item = await repo.update(non_existent_id, {'name': 'NoItem'})
+    updated_item = await repo.update_id(non_existent_id, {'name': 'NoItem'})
     assert updated_item is None
 
     deleted_item = await repo.delete(non_existent_id)


### PR DESCRIPTION
## Refactor of QAFService.py
This main change in this service is the removal of `ConversationRepository` as a class variable.
A refactor has also been done one conversation specific methods in this service where possible, they have been moved to `ConversationService`.

## Conversation copy
Change introduce to create a conversation copy.
PR has support for creating an **inactive** copy of a conversation and setting **active** conversation. Only one conversation in a series (a series is the root and any copy of a conversation) can be set as active and an active conversation will be de displayed as default conversation for the user.
Main respoinsible methods are `create_inactive_copy_of_conversation` and `set_active_conversation` in class `ConversationService`

### DB model for handling conversation copy
- Root object of a conversation will be tracked by setting `conversation_root_id` to `None`.
- Copy objects of a conversation will track the root by setting `conversation_root_id` to the root conversation ID.
- Every conversation will have a unique `conversation_id` and the root of the conversation will keep track of active conversation by setting `conversation_active_id`

Revised conversation model with all fields, Pydantic config and validators:
```python
class Conversation(BaseModel):
    id: ObjectId = Field(alias='_id')
    type: str = 'conversation'
    created_by: str
    participants: List[str]
    messages: List[Message] = Field(default_factory=list)
    conversation_id: UUID4 = Field(default_factory=uuid4)   # ID used to track the conversation and its copies
    conversation_root_id: UUID4 | None = None               # Any copy of the conversation will have the same root ID
    conversation_active_id: UUID4                           # The root conversation will track the active conversation
    timestamp: Timestamp = Timestamp()
    metadata: dict = Field(default_factory=dict)
    tags: List[str] | None = Field(default_factory=list)

    class Config:
        populate_by_name = True             # Populate model fields by name instead of alias if present
        arbitrary_types_allowed = True      # Allow arbitrary types (e.g. ObjectId)
        json_encoders = {ObjectId: str}     # `ObjectId` not serializable by default
        orm_mode = True

    @validator('id', pre=True, always=True)
    def ensure_object_id(cls, v):
        if isinstance(v, str):
            return ObjectId(v)
        return v
```