### PR TITLE
Feat/conversation copy

### DIFF
--- a/fai-rag-app/fai-backend/fai_backend/conversations/models.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/models.py
@@ -1,5 +1,6 @@
+from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, UUID4
 
 from fai_backend.schema import Timestamp
 
@@ -31,3 +32,7 @@ class Conversation(BaseModel):
     timestamp: Timestamp = Timestamp()
     metadata: dict = Field(default_factory=dict)
     tags: list[str] | None = Field(default_factory=list)
+    conversation_id: UUID4 = Field(default_factory=uuid4)   # ID used to track the conversation and its copies
+    conversation_root_id: UUID4 | None = None               # Any copy of the conversation will have the same root ID
+    conversation_active_id: UUID4 | None = None             # The root conversation will track the active conversation
+

--- a/fai-rag-app/fai-backend/fai_backend/conversations/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/service.py
@@ -1,4 +1,6 @@
-from pydantic import EmailStr
+from uuid import uuid4
+
+from pydantic import EmailStr, UUID4
 
 from fai_backend.conversations.models import Conversation
 from fai_backend.conversations.schema import (
@@ -7,6 +9,7 @@ from fai_backend.conversations.schema import (
     ResponseMessage,
 )
 from fai_backend.repositories import ConversationRepository
+from fai_backend.repository.query.component import LogicalExpression, AttributeAssignment
 
 
 class ConversationService:
@@ -30,6 +33,27 @@ class ConversationService:
         return Conversation.model_validate((await self.conversations_repo.create(
             Conversation.model_validate(conversation.model_dump(exclude={'id'}))
         )).model_dump())
+
+    @staticmethod
+    def get_conversation_copy(conversation: Conversation) -> Conversation:
+        conversation_copy = conversation.dict()
+
+        conversation_copy.update({
+            'id': str(uuid4()),
+            'conversation_id': uuid4(),
+            'conversation_root_id': conversation.conversation_id,
+            'conversation_active_id': None
+        })
+
+        return Conversation.model_validate(conversation_copy)
+
+    async def set_active_conversation(self, conversation_to_activate: Conversation):
+        root_id = AttributeAssignment('conversation_id', conversation_to_activate.conversation_root_id)
+        root_conversation = (await self.conversations_repo.list(query=root_id))[0]
+
+        root_conversation.conversation_active_id = conversation_to_activate.conversation_id
+        new_conversation_active_id = {'conversation_active_id': conversation_to_activate.conversation_id}
+        return await self.conversations_repo.update(root_conversation.id, new_conversation_active_id)
 
     async def add_feedback(self, message, email, body) -> FeedbackResponse | None:
         pass

--- a/fai-rag-app/fai-backend/fai_backend/conversations/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/conversations/service.py
@@ -51,7 +51,6 @@ class ConversationService:
         root_id = AttributeAssignment('conversation_id', conversation_to_activate.conversation_root_id)
         root_conversation = (await self.conversations_repo.list(query=root_id))[0]
 
-        root_conversation.conversation_active_id = conversation_to_activate.conversation_id
         new_conversation_active_id = {'conversation_active_id': conversation_to_activate.conversation_id}
         return await self.conversations_repo.update(root_conversation.id, new_conversation_active_id)
 

--- a/fai-rag-app/fai-backend/tests/conversations/test_conversations_service.py
+++ b/fai-rag-app/fai-backend/tests/conversations/test_conversations_service.py
@@ -1,0 +1,92 @@
+from typing import cast
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from beanie import init_beanie
+from mongomock_motor import AsyncMongoMockClient
+
+from fai_backend.conversations.models import Conversation, Message
+from fai_backend.conversations.service import ConversationService
+from fai_backend.repositories import ConversationDocument, ConversationRepository
+from fai_backend.repository.mongodb import MongoDBRepo
+from fai_backend.schema import ProjectUser
+
+
+def test_get_conversation_copy():
+    project_user = ProjectUser(
+        email='jane.doe@mail.com',
+        role='user',
+        project_id='1234',
+        permissions={'can_ask_questions': True}
+    )
+
+    conversation = Conversation(
+        id='temp_id',
+        created_by=project_user.email,
+        participants=[project_user.email],
+        type='question',
+        messages=[
+            Message(
+                user='user',
+                created_by=project_user.email,
+                content='Some question',
+                type='question'
+            )
+        ]
+    )
+
+    conversation_copy = ConversationService.get_conversation_copy(conversation)
+
+    assert conversation_copy.id != conversation.id
+    assert conversation_copy.conversation_id != conversation.conversation_id
+    assert conversation_copy.conversation_root_id == conversation.conversation_id
+    assert conversation_copy.conversation_active_id is None
+
+
+@pytest_asyncio.fixture
+async def conversation_repo() -> ConversationRepository:
+    await init_beanie(database=AsyncMongoMockClient().test_db, document_models=[ConversationDocument])
+    yield MongoDBRepo[Conversation, ConversationDocument](Conversation, ConversationDocument)
+    await ConversationDocument.get_motor_collection().drop()
+
+
+@pytest.mark.asyncio
+async def test_set_active_conversation(conversation_repo):
+    conversation_service = ConversationService(conversation_repo)
+
+    project_user = ProjectUser(
+        email='jane.doe@mail.com',
+        role='user',
+        project_id='1234',
+        permissions={'can_ask_questions': True}
+    )
+
+    root_conversation_id = uuid4()
+    root_conversation = Conversation(
+        id='temp_id',
+        project_id='1234',
+        created_by=project_user.email,
+        participants=[project_user.email],
+        type='question',
+        messages=[
+            Message(
+                user='user',
+                created_by=project_user.email,
+                content='Some question',
+                type='question'
+            )
+        ],
+        conversation_id=root_conversation_id,
+        conversation_root_id=None,
+        conversation_active_id=root_conversation_id
+    )
+
+    root_conversation_in_db = await conversation_service.conversations_repo.create(root_conversation)
+
+    conversation_copy = ConversationService.get_conversation_copy(root_conversation_in_db)
+    conversation_copy_in_db = await conversation_service.conversations_repo.create(conversation_copy)
+
+    updated_root_active_id = await conversation_service.set_active_conversation(conversation_copy_in_db)
+
+    assert updated_root_active_id.conversation_active_id == conversation_copy_in_db.conversation_id


### PR DESCRIPTION
## Conversation copy
Change introduce to create a conversation copy.
PR has support for creating an **inactive** copy of a conversation and setting **active** conversation. Only one conversation in a series (a series is the root and any copy of a conversation) can be set as active and an active conversation will be de displayed as default conversation for the user.
Main respoinsible methods are `create_inactive_copy_of_conversation` and `set_active_conversation` in class `ConversationService`

### DB model for handling conversation copy
- Root object of a conversation will be tracked by setting `conversation_root_id` to `None`.
- Copy objects of a conversation will track the root by setting `conversation_root_id` to the root conversation ID.
- Every conversation will have a unique `conversation_id` and the root of the conversation will keep track of active conversation by setting `conversation_active_id`

Revised conversation model:
```python
class Conversation(BaseModel):
    id: str
    type: str = 'conversation'
    created_by: str
    participants: list[str]
    messages: list[Message]
    timestamp: Timestamp = Timestamp()
    metadata: dict = Field(default_factory=dict)
    tags: list[str] | None = Field(default_factory=list)
    conversation_id: UUID4 = Field(default_factory=uuid4)   # ID used to track the conversation and its copies
    conversation_root_id: UUID4 | None = None               # Any copy of the conversation will have the same root ID
    conversation_active_id: UUID4 | None = None             # The root conversation will track the active conversation

```