### PR TITLE
fix(qaf): rename view endpoints

### DIFF
--- a/fai-rag-app/fai-backend/fai_backend/main.py
+++ b/fai-rag-app/fai-backend/fai_backend/main.py
@@ -153,7 +153,7 @@ async def greet(language: str = Header(default='en')):
 
 @app.get('/api', include_in_schema=True)
 async def root(project_user: ProjectUser = Depends(get_project_user)):
-    return RedirectResponse(url='/api/chat', status_code=302)
+    return RedirectResponse(url='/api/view/chat', status_code=302)
 
 
 @app.get('/api/{path:path}', status_code=404)

--- a/fai-rag-app/fai-backend/fai_backend/qaf/menu.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/menu.py
@@ -23,7 +23,7 @@ async def qa_menu_loader(
         *[
             (
                 f'{status.capitalize()}',
-                f'/questions?review_status={status}',
+                f'/view/questions?review_status={status}',
                 await get_count_by_review_status(status) or '0',
 
             )
@@ -47,8 +47,8 @@ def qa_menu(
             components=[
                 c.Link(
                     text=_('show_all', 'Visa alla'),
-                    url='/questions',
-                    active='/questions*'
+                    url='/view/questions',
+                    active='/view/questions*'
                 ),
                 *([c.Menu(
                     title=_('status', 'Status'),
@@ -63,8 +63,8 @@ def qa_menu(
                 )] if items else []),
                 c.Link(
                     text=_('Add new question'),
-                    url='/questions/create',
-                    active='/questions/create',
+                    url='/view/questions/create',
+                    active='/view/questions/create',
                     icon_src=icons['plus'],
                 ),
             ],

--- a/fai-rag-app/fai-backend/fai_backend/qaf/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/routes.py
@@ -56,7 +56,7 @@ async def llm_raq_question_endpoint(
         raise HTTPException(status_code=500, detail=str(exception))
 
 
-@router.get('/chat', response_model=list, response_model_exclude_none=True)
+@router.get('/view/chat', response_model=list, response_model_exclude_none=True)
 def chat_index_view(
         authenticated_user: User | None = Depends(get_project_user),
         view=Depends(get_page_template_for_logged_in_users),

--- a/fai-rag-app/fai-backend/fai_backend/qaf/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/routes.py
@@ -90,7 +90,7 @@ def to_table_data(question: QuestionDetails) -> dict[str, Any]:
         'timestamp.modified': format_datetime_human_readable(question.timestamp.modified, 1),
         'tags': question.tags,
         'review_status': question.review_status,
-        'link': f'/questions/{question.id}',
+        'link': f'/view/questions/{question.id}',
     }
 
 
@@ -106,7 +106,7 @@ def question_fields() -> list[dict]:
     ]
 
 
-@router.get('/questions', response_model=list, response_model_exclude_none=True)
+@router.get('/view/questions', response_model=list, response_model_exclude_none=True)
 def questions(data: list[QuestionDetails] = Depends(questions_loader),
               view=Depends(get_page_template_for_logged_in_users)):
     return view(
@@ -124,7 +124,7 @@ def questions(data: list[QuestionDetails] = Depends(questions_loader),
                     id='question',
                     label=_('question', 'Question'),
                     display=DisplayAs.link,
-                    on_click=e.GoToEvent(url='/questions/{id}'),
+                    on_click=e.GoToEvent(url='/view/questions/{id}'),
                     sortable=True,
                     # filter=ColumnFilter.search,
                 ),
@@ -187,53 +187,53 @@ def questions(data: list[QuestionDetails] = Depends(questions_loader),
     )
 
 
-@router.get('/questions/create', response_model=list, response_model_exclude_none=True)
+@router.get('/view/questions/create', response_model=list, response_model_exclude_none=True)
 def create_question(
         view: Callable[[list[Any], str | None], list[Any]] = Depends(get_page_template_for_logged_in_users),
 ) -> list:
-    return QuestionForm(view, '/api/questions/create')
+    return QuestionForm(view, '/api/view/questions/create')
 
 
-@router.post('/questions/create', response_model=list, response_model_exclude_none=True)
+@router.post('/view/questions/create', response_model=list, response_model_exclude_none=True)
 def on_create_question(
         data: QuestionDetails = Depends(run_llm_on_question_create_action),
         view=Depends(get_page_template_for_logged_in_users),
 ) -> list:
     return view(
-        [c.FireEvent(event=e.GoToEvent(url=f'/questions/{data.id}'))],
+        [c.FireEvent(event=e.GoToEvent(url=f'/view/questions/{data.id}'))],
         _('submit_a_question', 'Create Question'''),
     )
 
 
-@router.get('/questions/{conversation_id}', response_model=list, response_model_exclude_none=True)
+@router.get('/view/questions/{conversation_id}', response_model=list, response_model_exclude_none=True)
 async def question_details(
         data: QuestionDetails = Depends(question_details_loader),
         view=Depends(get_page_template_for_logged_in_users),
         authenticated_user: ProjectUser | None = Depends(get_project_user),
 ) -> list:
     if not data:
-        return [c.FireEvent(event=e.GoToEvent(url='/questions'))]
+        return [c.FireEvent(event=e.GoToEvent(url='/view/questions'))]
 
     return ReviewDetails(authenticated_user, data, view, meta_data=to_table_data(data), meta_fields=question_fields())
 
 
-@router.post('/questions/{conversation_id}/feedback', response_model=list, response_model_exclude_none=True)
+@router.post('/view/questions/{conversation_id}/feedback', response_model=list, response_model_exclude_none=True)
 def on_submit_feedback(
         data: QuestionDetails = Depends(add_feedback_action),
         view=Depends(get_page_template_for_logged_in_users),
 ) -> list:
     return view(
-        [c.FireEvent(event=e.GoToEvent(url=f'/questions/{data.id}'))],
+        [c.FireEvent(event=e.GoToEvent(url=f'/view/questions/{data.id}'))],
         page_title=_('submit_a_question', 'Create Question'''),
     )
 
 
-@router.post('/questions/{conversation_id}/answer', response_model=list, response_model_exclude_none=True)
+@router.post('/view/questions/{conversation_id}/answer', response_model=list, response_model_exclude_none=True)
 def on_submit_answer(
         question: QuestionDetails = Depends(add_answer_action),
         view=Depends(get_page_template_for_logged_in_users),
 ) -> list:
     return view(
-        [c.FireEvent(event=e.GoToEvent(url=f'/questions/{question.id}'))],
+        [c.FireEvent(event=e.GoToEvent(url=f'/view/questions/{question.id}'))],
         _('submit_a_question', 'Create Question'''),
     )

--- a/fai-rag-app/fai-backend/fai_backend/qaf/views.py
+++ b/fai-rag-app/fai-backend/fai_backend/qaf/views.py
@@ -208,7 +208,7 @@ def ReviewDetails(user: ProjectUser, question: QuestionDetails, view, meta_data:
     review_state = {
         'open': lambda: [
             c.Form(
-                submit_url=f'/api/questions/{question.id}/feedback',
+                submit_url=f'/api/view/questions/{question.id}/feedback',
                 method='POST',
                 submit_text=_('create_question_submit_button', 'Submit'),
                 components=[
@@ -233,7 +233,7 @@ def ReviewDetails(user: ProjectUser, question: QuestionDetails, view, meta_data:
         ],
         'in-progress': lambda: [
             c.Form(
-                submit_url=f'/api/questions/{question.id}/answer',
+                submit_url=f'/api/view/questions/{question.id}/answer',
                 method='POST',
                 submit_text=_('create_question_submit_button', 'Submit'),
                 components=[

--- a/fai-rag-app/fai-backend/fai_backend/views.py
+++ b/fai-rag-app/fai-backend/fai_backend/views.py
@@ -37,9 +37,9 @@ def chat_menu() -> list:
     return [
         c.Link(
             text=_('chat', 'Chat'),
-            url='/chat',
+            url='/view/chat',
             icon_src=icons['message_square_more'],
-            active='/chat*'
+            active='/view/chat*'
         )
     ]
 

--- a/fai-rag-app/fai-frontend/src/lib/components/table/data-table.ts
+++ b/fai-rag-app/fai-frontend/src/lib/components/table/data-table.ts
@@ -148,7 +148,7 @@ export const withIndexColumnLeft = <T>(table: Table<T>, columns: Column<T>[]) =>
 export const withActionColumnRight = <T>(
   table: Table<T>,
   columns: Column<T>[],
-  path: string = '/questions/',
+  path: string = '/view/questions/',
   key: string = '',
 ) => [
   ...columns,


### PR DESCRIPTION
Endpoints that return view components should be named like `.../api/view/some-view`.
Implemented example for chat endpoints.

Would like to rename the endpoints before trying to working on collections as the endpoints are confusing.