### PR TITLE
✨ Feat(vllm): support for multiple local models (vllm instances)

### DIFF
--- a/data/assistant-templates/gpt-sw3-20b.json
+++ b/data/assistant-templates/gpt-sw3-20b.json
@@ -1,0 +1,30 @@
+{
+  "id": "gpt-sw3-20b",
+  "meta": {
+    "name": "AI Sweden GPT-SW3 Assistant",
+    "description": "AI Sweden GPT-SW3 (20B) exempel. Modellen körs på egen-managerad vLLM instans.",
+    "sample_questions": []
+  },
+  "streams": [
+    {
+      "provider": "vllm",
+      "settings": {
+        "model": "AI-Sweden-Models/gpt-sw3-20b-instruct",
+        "temperature": 0
+      },
+      "messages": [
+        {
+          "role": "system",
+          "content": "You are a helpful AI assistant that answers questions. The questions are going to be asked in Swedish. Your response must always be in Swedish."
+        },
+        {
+          "insert": "history"
+        },
+        {
+          "role": "user",
+          "content": "{query}"
+        }
+      ]
+    }
+  ]
+}

--- a/data/assistant-templates/llama-3.1-8b.json
+++ b/data/assistant-templates/llama-3.1-8b.json
@@ -1,0 +1,30 @@
+{
+  "id": "llama-3.1-8b",
+  "meta": {
+    "name": "LLama 3.1 (8b) Assistant",
+    "description": "LLama 3.1 (8b) exempel. Modellen körs på egen-managerad vLLM instans.",
+    "sample_questions": []
+  },
+  "streams": [
+    {
+      "provider": "vllm",
+      "settings": {
+        "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        "temperature": 0
+      },
+      "messages": [
+        {
+          "role": "system",
+          "content": "You are a helpful AI assistant that answers questions. The questions are going to be asked in Swedish. Your response must always be in Swedish."
+        },
+        {
+          "insert": "history"
+        },
+        {
+          "role": "user",
+          "content": "{query}"
+        }
+      ]
+    }
+  ]
+}

--- a/fai-rag-app/fai-backend/.env.example
+++ b/fai-rag-app/fai-backend/.env.example
@@ -104,9 +104,9 @@ LLM_BACKEND=parrot
 # See https://platform.openai.com/ for more info.
 OPENAI_API_KEY=my-openai-key
 
-# URI and API key to vLLM instance when using provider=vllm in templates
-VLLM_URI=
-VLLM_API_KEY=
+# configuration for vLLM models. JSON dict where key=model and value={ url, key }
+# example, VLLM_CONFIG={"meta-llama/Meta-Llama-3.1-8B-Instruct":{"url":"https://api.runpod.ai/v2/blabla/openai/v1","key":"my_key"}}
+VLLM_CONFIG=
 
 # Model name to use for chat prompt
 CHAT_MODEL=gpt-4o

--- a/fai-rag-app/fai-backend/fai_backend/config.py
+++ b/fai-rag-app/fai-backend/fai_backend/config.py
@@ -37,9 +37,8 @@ class Settings(BaseSettings, extra=Extra.ignore):
     SENTRY_EVENT_LEVEL: str = 'ERROR'
     SENTRY_TRACE_SAMPLE_RATE: float = 0.1
     SENTRY_ENVIRONMENT: str = 'development'
-    VLLM_URI: str = ''
-    VLLM_API_KEY: str = ''
-    FILE_SIZE_LIMIT: int = 10 # MB
+    VLLM_CONFIG: str = ''
+    FILE_SIZE_LIMIT: int = 10  # MB
 
     class Config:
         env_file = '.env'


### PR DESCRIPTION
Added support for multiple local models via multiple vLLM instances by providing a model-vLLM map instead of a single url + key.

To use set env `VLLM_CONFIG`, example:

```
VLLM_CONFIG={"meta-llama/Meta-Llama-3.1-8B-Instruct":{"url":"https://api.runpod.ai/v2/blabla/openai/v1","key":"my_key"}}
```

(replace `url`/`key` with correct values and use `meta-llama/Meta-Llama-3.1-8B-Instruct` as model and `vllm` as provider in an assistant)

(you can remove the old VLLM_URI/VLLM_API_KEY props)