### PR TITLE
✨ Feat(chat): store question before opening sse chat connection

### DIFF
--- a/fai-rag-app/fai-backend/fai_backend/assistant/models.py
+++ b/fai-rag-app/fai-backend/fai_backend/assistant/models.py
@@ -68,3 +68,12 @@ class AssistantChatHistoryModel(Document):
     class Settings:
         name = 'chat_history'
         use_state_management = True
+
+
+class StoredQuestionModel(Document):
+    question: str
+    user: str
+
+    class Settings:
+        name = 'stored_questions'
+        use_state_management = True

--- a/fai-rag-app/fai-backend/fai_backend/assistant/sse_routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/assistant/sse_routes.py
@@ -1,16 +1,18 @@
+import logging
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from sse_starlette import ServerSentEvent, EventSourceResponse
 
 from fai_backend.assistant.assistant import Assistant
 from fai_backend.assistant.models import LLMClientChatMessage, \
-    AssistantStreamMessage, AssistantChatHistoryModel
+    AssistantStreamMessage, AssistantChatHistoryModel, StoredQuestionModel
 from fai_backend.assistant.service import AssistantFactory
 from fai_backend.dependencies import get_authenticated_user
 from fai_backend.projects.dependencies import list_projects_request
 from fai_backend.projects.schema import ProjectResponse
-from fai_backend.repositories import chat_history_repo
+from fai_backend.repositories import chat_history_repo, stored_questions_repo
 from fai_backend.schema import User
 from fai_backend.serializer.impl.base64 import Base64Serializer
 
@@ -80,14 +82,42 @@ async def event_source_llm_generator(question: str, assistant: Assistant, conver
     return EventSourceResponse(generator(conversation_id))
 
 
+class StoreQuestionModel(BaseModel):
+    question: str
+
+
+@sse_router.post('/chat/question')
+async def store_question(
+        req: StoreQuestionModel,
+        project_user: User = Depends(get_authenticated_user)
+):
+    stored_question: StoredQuestionModel = await stored_questions_repo.create(StoredQuestionModel(
+        question=req.question,
+        user=project_user.email
+    ))
+
+    return {'id': str(stored_question.id)}
+
+
 @sse_router.get('/chat/stream/new/{project_id}/{assistant_id}')
 async def chat_assistant_stream_new(
         project_id: str,
         assistant_id: str,
-        question: str,
+        stored_question_id: str,
         projects: list[ProjectResponse] = Depends(list_projects_request),
         project_user: User = Depends(get_authenticated_user),
 ):
+    stored = await stored_questions_repo.get(stored_question_id)
+
+    if stored is None:
+        raise HTTPException(status_code=404)
+    if stored.user != project_user.email:
+        raise HTTPException(status_code=403)
+
+    await stored_questions_repo.delete(stored_question_id)
+
+    question = stored.question
+
     factory = AssistantFactory([a for p in projects for a in p.assistants if p.id == project_id])
     assistant_instance = factory.create_assistant(assistant_id)
     new_history_entry = await chat_history_repo.create(AssistantChatHistoryModel(
@@ -105,9 +135,20 @@ async def chat_assistant_stream_new(
 @sse_router.get('/chat/stream/continue/{conversation_id}')
 async def chat_assistant_stream_continue(
         conversation_id: str,
-        question: str,
+        stored_question_id: str,
         project_user: User = Depends(get_authenticated_user),
 ):
+    stored = await stored_questions_repo.get(stored_question_id)
+
+    if stored is None:
+        raise HTTPException(status_code=404)
+    if stored.user != project_user.email:
+        raise HTTPException(status_code=403)
+
+    await stored_questions_repo.delete(stored_question_id)
+
+    question = stored.question
+
     chat_history = await chat_history_repo.get(conversation_id)
 
     if chat_history is None or chat_history.user != project_user.email:

--- a/fai-rag-app/fai-backend/fai_backend/repositories.py
+++ b/fai-rag-app/fai-backend/fai_backend/repositories.py
@@ -4,7 +4,7 @@ from typing import Protocol
 from beanie import Document, Indexed
 from pydantic import EmailStr, Field
 
-from fai_backend.assistant.models import AssistantChatHistoryModel
+from fai_backend.assistant.models import AssistantChatHistoryModel, StoredQuestionModel
 from fai_backend.collection.models import CollectionMetadataModel
 from fai_backend.conversations.models import Conversation
 from fai_backend.projects.schema import Project
@@ -115,6 +115,10 @@ class CollectionMetadataRepository(IAsyncRepo[CollectionMetadataModel]):
     pass
 
 
+class StoredQuestionsRepository(IAsyncRepo[StoredQuestionModel]):
+    pass
+
+
 repo_factory.register_builder(
     {
         ProjectRepository: lambda: create_repo_from_env(ProjectModel, ProjectModel),
@@ -122,7 +126,8 @@ repo_factory.register_builder(
         PinCodeRepository: lambda: create_repo_from_env(PinCodeModel, PinCodeModel),
         ConversationRepository: lambda: create_repo_from_env(Conversation, ConversationDocument),
         ChatHistoryRepository: lambda: create_repo_from_env(AssistantChatHistoryModel, AssistantChatHistoryModel),
-        CollectionMetadataRepository: lambda: create_repo_from_env(CollectionMetadataModel, CollectionMetadataModel)
+        CollectionMetadataRepository: lambda: create_repo_from_env(CollectionMetadataModel, CollectionMetadataModel),
+        StoredQuestionsRepository: lambda: create_repo_from_env(StoredQuestionModel, StoredQuestionModel),
     }
 )
 
@@ -132,3 +137,4 @@ pins_repo = repo_factory.create(PinCodeRepository)
 conversation_repo = repo_factory.create(ConversationRepository)
 chat_history_repo = repo_factory.create(ChatHistoryRepository)
 collection_metadata_repo = repo_factory.create(CollectionMetadataRepository)
+stored_questions_repo = repo_factory.create(StoredQuestionsRepository)

--- a/fai-rag-app/fai-backend/fai_backend/setup.py
+++ b/fai-rag-app/fai-backend/fai_backend/setup.py
@@ -11,7 +11,7 @@ from fai_backend.collection.models import CollectionMetadataModel
 from fai_backend.config import settings
 from fai_backend.projects.schema import ProjectMember, ProjectRole
 from fai_backend.repositories import ConversationDocument, PinCodeModel, ProjectModel, projects_repo
-from fai_backend.assistant.models import AssistantTemplate, AssistantChatHistoryModel
+from fai_backend.assistant.models import AssistantTemplate, AssistantChatHistoryModel, StoredQuestionModel
 from fai_backend.sentry.watcher import Watcher
 
 
@@ -97,7 +97,8 @@ async def setup_db():
             PinCodeModel,
             ConversationDocument,
             AssistantChatHistoryModel,
-            CollectionMetadataModel
+            CollectionMetadataModel,
+            StoredQuestionModel
         ]
     )
 


### PR DESCRIPTION
Store chat question/prompt on backend and use a reference to it when opening the SSE chat connection, instead of sending the question it self over SSE as a query parameter.

Workaround for URL length limits and should allow for much longer queries.

Chat questions are stored temporarily in the primary database (probably mongodb) and are deleted as they're used by the SSE chat stream endpoints.