### PR TITLE
fix(chat): disable SvelteMarkdown mangle

### DIFF
--- a/fai-rag-app/fai-frontend/src/lib/components/ChatBubble.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/ChatBubble.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import SvelteMarkdown from 'svelte-markdown'
+  import SvelteMarkdownWrapper from "$lib/components/SvelteMarkdownWrapper.svelte";
 
   import Text from './Text.svelte'
 
@@ -29,7 +29,7 @@
     {#if time}
       <time class="text-xs opacity-50">{time}</time>
     {/if}
-    <slot name="header" />
+    <slot name="header"/>
   </div>
 
   <div
@@ -40,16 +40,16 @@
     class="prose chat-bubble min-h-fit text-base-content"
   >
     {#if enableMarkdown}
-      <SvelteMarkdown source={content} />
+      <SvelteMarkdownWrapper source={content}/>
     {:else}
       <span class="whitespace-pre-line">{content}</span>
     {/if}
-    <slot name="below-content" />
+    <slot name="below-content"/>
   </div>
 
   {#if $$slots.footer}
     <div class="chat-footer">
-      <slot name="footer" />
+      <slot name="footer"/>
     </div>
   {/if}
 </div>

--- a/fai-rag-app/fai-frontend/src/lib/components/SSEChat.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/SSEChat.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import Button from './Button.svelte'
   import ChatBubble from './ChatBubble.svelte'
-  import SvelteMarkdown from 'svelte-markdown'
+  import SvelteMarkdownWrapper from '$lib/components/SvelteMarkdownWrapper.svelte';
   import SVG from '$lib/components/SVG.svelte'
-  import { findLastIndex } from '../../util/array'
-  import type { Action } from 'svelte/action'
+  import {findLastIndex} from '../../util/array'
+  import type {Action} from 'svelte/action'
 
   interface IncomingMessage {
     timestamp: string
@@ -82,23 +82,23 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
     isContentAtBottom =
       contentScrollDiv &&
       contentScrollDiv.scrollHeight -
-        contentScrollDiv.scrollTop -
-        contentScrollDiv.clientHeight <=
-        margin
+      contentScrollDiv.scrollTop -
+      contentScrollDiv.clientHeight <=
+      margin
   }
 
   $: selectedAssistant = assistants.find((a) => a.id === selectedAssistantId) || null
   $: contentScrollDiv &&
-    messages &&
-    messages.length > 0 &&
-    isContentAtBottom &&
-    scrollContentToBottom()
+  messages &&
+  messages.length > 0 &&
+  isContentAtBottom &&
+  scrollContentToBottom()
   $: lastMessageErrored && setTimeout(scrollContentToBottom, 100)
   $: invalidInputLength =
     (maxInputLength ?? 0) > 0 && currentMessageInput.length > (maxInputLength ?? 0)
 
   const scrollToBottom = (node: Element) => {
-    node.scroll({ top: node.scrollHeight, behavior: 'smooth' })
+    node.scroll({top: node.scrollHeight, behavior: 'smooth'})
   }
 
   function scrollContentToBottom() {
@@ -152,7 +152,7 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
 
     fetch('/api/sse/chat/question', {
       method: 'POST',
-      body: JSON.stringify({ question }),
+      body: JSON.stringify({question}),
       headers: {
         'Content-Type': 'application/json',
       },
@@ -303,7 +303,7 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
       {:else}
         <div class="prose">
           {#if selectedAssistant}
-            <SvelteMarkdown source={selectedAssistant.description} />
+            <SvelteMarkdownWrapper source={selectedAssistant.description}/>
             <div class="flex gap-2 max-w-full flex-wrap justify-center">
               {#each selectedAssistant.sampleQuestions as question}
                 <button
@@ -321,7 +321,7 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
             </p>
             <p>Choose an assistant from the dropdown to begin.</p>
             {#if termOfService}
-              <SvelteMarkdown source={termOfService} />
+              <SvelteMarkdownWrapper source={termOfService}/>
             {/if}
           {/if}
         </div>
@@ -330,13 +330,13 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
       {#if lastMessageErrored}
         <div class="flex items-center gap-2">
           <span>Ett fel uppstod ⚠️️</span>
-          <button class="btn btn-link active:opacity-60" on:click={retryLastMessage}
-            >Försök igen</button
-          >
+          <button class="btn btn-link active:opacity-60" on:click={retryLastMessage}>
+            Försök igen
+          </button>
         </div>
       {/if}
 
-      <span class="loading loading-spinner" class:opacity-0={!eventSource} />
+      <span class="loading loading-spinner" class:opacity-0={!eventSource}/>
     </div>
   </div>
 
@@ -352,10 +352,10 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
             <span
               class:hidden={(maxInputLength ?? 0) <= 0}
               class="block text-right text-xs"
-              ><span
-                class:text-error={invalidInputLength}
-                class:text-medium={invalidInputLength}>{currentMessageInput.length}</span
-              >
+            ><span
+              class:text-error={invalidInputLength}
+              class:text-medium={invalidInputLength}>{currentMessageInput.length}</span
+            >
               / {maxInputLength}</span
             >
             <textarea

--- a/fai-rag-app/fai-frontend/src/lib/components/SvelteMarkdownWrapper.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/SvelteMarkdownWrapper.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import SvelteMarkdown from 'svelte-markdown';
+
+  export let source;
+  export let options = {};
+
+  const defaultOptions = {
+    mangle: false
+  }
+
+  const mergedOptions = {
+    ...defaultOptions,
+    ...options
+  }
+</script>
+
+<SvelteMarkdown {source} options={mergedOptions}/>


### PR DESCRIPTION
This PR addresses the issue of garbled email links in Markdown, as reported here: https://github.com/pablo-abc/svelte-markdown/issues/50

I have added a new Svelte component, `SvelteMarkdownWrapper.svelte`. This component extends `SvelteMarkdown` by adding extra configuration options. `SvelteMarkdownWrapper.svelte` also allows for future Markdown customization. For instance, to implement a custom link renderer:
```js
<script>
  import SvelteMarkdown from 'svelte-markdown';
 // Rest of the imports

  const defaultOptions = {
    mangle: false
  };

  // Create a custom renderer
  const renderer = new marked.Renderer();

  // Customize the link rendering (e.g., open links in new tab)
  renderer.link = (href, title, text) => {
    return `<a href="${href}" title="${title || ''}" target="_blank" rel="noopener noreferrer">${text}</a>`;
  };

  // Merge options
  const mergedOptions = {
    ...defaultOptions,
    ...options,
    renderer,
  };
</script>
```

**Testing**
The fix can be verified by adding an email link to the SSEChat.svelte terms of service. Here is how the terms of service have been updated:

```js
  export let termOfService: string = `
---

### Terms of Service for Folkets AI
Welcome to our AI chat service. By using this service, you agree to the following terms:

**1. Avoid Sharing Personal Information**
* **Do not enter personal or sensitive data into the chat.** This includes, but is not limited to, social security numbers, addresses, financial information, or any other confidential details.

**2. Data Handling and Third Parties**
* Information entered into the chat may be stored and processed by third-party services.
* The chat uses various logging tools to improve the service and user experience.

**3. Limitation of Liability**
 * The service is provided "as is".

---
By continuing to use Folkets AI, you confirm that you have read, understood, and agree to these terms of service.

Contact some-support@some-mail.com for any questions.

    `
```

**Note**: An `NS_ERROR_FAILURE` may occur when clicking the email link in the above test, however I don't believe this is happens on the server and should not be an issue.