### PR TITLE
Fix/refine mobile nav

### DIFF
--- a/fai-rag-app/fai-backend/fai_backend/views.py
+++ b/fai-rag-app/fai-backend/fai_backend/views.py
@@ -89,7 +89,7 @@ def page_template(*components, page_title: str = None, menus: list | None = None
     def page_title_component() -> list:
         return [c.Heading(
             text=page_title,
-            class_name='flex-1 lg:flex-none font-semibold text-base-content',
+            class_name='flex-1 text-center lg:text-left lg:flex-none font-semibold text-base-content truncate text-nowrap overflow-hidden',
         )] if page_title else []
 
     return [

--- a/fai-rag-app/fai-frontend/src/lib/components/AppHeader.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/AppHeader.svelte
@@ -8,7 +8,7 @@
   class="navbar sticky top-0 z-20 w-full border-b border-neutral border-opacity-25 bg-base-100 bg-opacity-40 px-0 tracking-tight backdrop-blur"
 >
   <div class="w-full px-4">
-    <div class="flex-1 lg:hidden lg:flex-none">
+    <div class="flex-0 lg:hidden lg:flex-none">
       <label for="my-drawer-2" aria-label="open sidebar" class="btn btn-square btn-ghost">
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/fai-rag-app/fai-frontend/src/lib/components/AppHeader.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/AppHeader.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <nav
-  class="navbar sticky top-0 z-50 w-full border-b border-neutral border-opacity-25 bg-base-100 bg-opacity-40 px-0 tracking-tight backdrop-blur"
+  class="navbar sticky top-0 z-20 w-full border-b border-neutral border-opacity-25 bg-base-100 bg-opacity-40 px-0 tracking-tight backdrop-blur"
 >
   <div class="w-full px-4">
     <div class="flex-1 lg:hidden lg:flex-none">

--- a/fai-rag-app/fai-frontend/src/lib/components/AppHeader.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/AppHeader.svelte
@@ -1,24 +1,34 @@
 <script lang="ts">
-    import {type IRenderableComponent} from "../types";
+  import { type IRenderableComponent } from '../types'
 
-    export let components: IRenderableComponent[] = []
+  export let components: IRenderableComponent[] = []
 </script>
 
-<nav class="navbar tracking-tight top-0 sticky w-full bg-opacity-40 bg-base-100 backdrop-blur px-0 border-neutral border-opacity-25 border-b z-50">
-    <div class="px-4 w-full">
-        <div class="flex-1 lg:flex-none lg:hidden">
-            <label for="my-drawer-2" aria-label="open sidebar" class="btn btn-square btn-ghost">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                     class="inline-block w-6 h-6 stroke-current">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                          d="M4 6h16M4 12h16M4 18h16"></path>
-                </svg>
-            </label>
-        </div>
-        <slot>
-            {#each components as component}
-                <svelte:component this={component.type} {...component.props}/>
-            {/each}
-        </slot>
+<nav
+  class="navbar sticky top-0 z-50 w-full border-b border-neutral border-opacity-25 bg-base-100 bg-opacity-40 px-0 tracking-tight backdrop-blur"
+>
+  <div class="w-full px-4">
+    <div class="flex-1 lg:hidden lg:flex-none">
+      <label for="my-drawer-2" aria-label="open sidebar" class="btn btn-square btn-ghost">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          class="inline-block h-6 w-6 stroke-current"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 6h16M4 12h16M4 18h16"
+          ></path>
+        </svg>
+      </label>
     </div>
+    <slot>
+      {#each components as component}
+        <svelte:component this={component.type} {...component.props} />
+      {/each}
+    </slot>
+  </div>
 </nav>

--- a/fai-rag-app/fai-frontend/src/lib/components/AppShell.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/AppShell.svelte
@@ -1,13 +1,29 @@
 <script lang="ts">
+  import { path, searchParams, url } from 'elegua'
+  export let hasDrawer: boolean | null = null
 
-    export let hasDrawer: boolean | null = null
+  let drawerIsOpen = false
+
+  const closeOnChange = (_: any) => false
+
+  $: drawerIsOpen = closeOnChange($url)
 </script>
 
-<div class:drawer={$$slots?.drawer || hasDrawer} class:lg:drawer-open={$$slots?.drawer || hasDrawer} {...$$props}>
-    {#if $$slots?.drawer || hasDrawer}
-        <input id="my-drawer-2" type="checkbox" class="drawer-toggle"/>
-        <slot name="drawer"/>
-    {/if}
+<div
+  class:drawer={$$slots?.drawer || hasDrawer}
+  class:lg:drawer-open={$$slots?.drawer || hasDrawer}
+  {...$$props}
+>
+  {#if $$slots?.drawer || hasDrawer}
+    <input
+      id="my-drawer-2"
+      type="checkbox"
+      class="drawer-toggle"
+      checked={drawerIsOpen}
+      on:change={() => (drawerIsOpen = !drawerIsOpen)}
+    />
+    <slot name="drawer" />
+  {/if}
 
-    <slot/>
+  <slot />
 </div>

--- a/fai-rag-app/fai-frontend/src/lib/components/Content.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/Content.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { path, searchParams, url } from 'elegua'
+  import { pageDataStore } from '$lib/store'
 </script>
 
-{#key $url}
+{#key $pageDataStore}
   <slot />
 {/key}

--- a/fai-rag-app/fai-frontend/src/lib/components/Content.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/Content.svelte
@@ -1,1 +1,7 @@
-<slot/>
+<script lang="ts">
+  import { path, searchParams, url } from 'elegua'
+</script>
+
+{#key $url}
+  <slot />
+{/key}


### PR DESCRIPTION
- Center page header title in mobile
- Re-render content components when navigation/routing occurs
- Close drawer when navigation/routing occurs
- Increase z-index on drawer to display correctly in mobile


https://github.com/helsingborg-stad/F-AI/issues/169
https://github.com/helsingborg-stad/F-AI/issues/168

