### PR TITLE
Feat: support for uploading files in chat

### DIFF
--- a/fai-rag-app/fai-backend/fai_backend/assistant/form.py
+++ b/fai-rag-app/fai-backend/fai_backend/assistant/form.py
@@ -74,6 +74,15 @@ def AssistantForm(
                     ),
 
                     c.Select(
+                        name='allow_inline_files',
+                        label=_('Allow users to attach files in chat'),
+                        required=True,
+                        options=[('True', 'Yes'), ('False', 'No')],
+                        value=str(data.allow_inline_files) if data else "False",
+                        size='sm'
+                    ),
+
+                    c.Select(
                         name='files_collection_id',
                         label=_('Collection ID'),
                         required=False,

--- a/fai-rag-app/fai-backend/fai_backend/assistant/models.py
+++ b/fai-rag-app/fai-backend/fai_backend/assistant/models.py
@@ -41,6 +41,7 @@ class AssistantTemplate(BaseModel):
     id: str
     meta: AssistantTemplateMeta
     max_tokens: int = -1
+    allow_inline_files: bool = False
     files_collection_id: Optional[str] = None
     streams: list[AssistantStreamConfig | AssistantStreamPipelineDef]
 

--- a/fai-rag-app/fai-backend/fai_backend/assistant/schema.py
+++ b/fai-rag-app/fai-backend/fai_backend/assistant/schema.py
@@ -12,4 +12,5 @@ class TemplatePayload(BaseModel):
     sample_questions: list[str | None] | None = None
     files_collection_id: str | None = None
     response_format: str | None = None
+    allow_inline_files: bool = False
     delete_label: str = "Delete"  # TODO: fix hack for allowing something to show up in list to click on.

--- a/fai-rag-app/fai-backend/fai_backend/assistant/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/assistant/service.py
@@ -90,7 +90,8 @@ class TemplatePayloadAdapter:
                                                                                                    0].settings else None,
                 instructions=template.streams[0].messages[0].content or '',
                 files_collection_id=template.files_collection_id,
-                max_tokens=template.max_tokens
+                max_tokens=template.max_tokens,
+                allow_inline_files=template.allow_inline_files
             )
 
         def rag_stream_adapter():
@@ -107,7 +108,8 @@ class TemplatePayloadAdapter:
                                                                                                    1].settings else None,
                 instructions=template.streams[1].messages[0].content or '',
                 files_collection_id=template.files_collection_id,
-                max_tokens=template.max_tokens
+                max_tokens=template.max_tokens,
+                allow_inline_files=template.allow_inline_files
             )
 
         return basic_stream_adapter() if len(template.streams) == 1 else rag_stream_adapter()
@@ -179,6 +181,7 @@ class TemplatePayloadAdapter:
                     payload.sample_questions) > 0 else []
             ),
             max_tokens=payload.max_tokens,
+            allow_inline_files=payload.allow_inline_files,
             files_collection_id=payload.files_collection_id,
             streams=basic_stream() if payload.files_collection_id is '' else rag_stream()
         )

--- a/fai-rag-app/fai-backend/fai_backend/files/file_parser.py
+++ b/fai-rag-app/fai-backend/fai_backend/files/file_parser.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod, ABC
 
 import magic
+from unstructured.documents.elements import Element
 from unstructured.partition.docx import partition_docx
 from unstructured.partition.md import partition_md
 from unstructured.partition.pdf import partition_pdf
@@ -10,7 +11,7 @@ from unstructured.partition.html import partition_html
 
 class AbstractDocumentParser(ABC):
     @abstractmethod
-    def parse(self, filename: str):
+    def parse(self, filename: str) -> list[Element]:
         pass
 
 

--- a/fai-rag-app/fai-backend/fai_backend/framework/components.py
+++ b/fai-rag-app/fai-backend/fai_backend/framework/components.py
@@ -290,6 +290,7 @@ class Assistant(BaseModel):
     description: str
     sampleQuestions: list[str]
     maxTokens: int
+    allowInlineFiles: bool
 
 
 class SSEChat(UIComponent):

--- a/fai-rag-app/fai-backend/fai_backend/new_chat/models.py
+++ b/fai-rag-app/fai-backend/fai_backend/new_chat/models.py
@@ -12,6 +12,7 @@ class ClientChatState(BaseModel):
     rename_label: str = "Rename"  # TODO: fix hack for allowing something to show up in list to click on.
     history: list[LLMClientChatMessage]
     max_tokens: int
+    allow_inline_files: bool
 
 
 class ChatHistoryEditPayload(BaseModel):

--- a/fai-rag-app/fai-backend/fai_backend/new_chat/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/new_chat/routes.py
@@ -34,6 +34,7 @@ def chat_index_view(authenticated_user: ProjectUser | None = Depends(get_project
                               project=p.id,
                               description=a.meta.description,
                               maxTokens=a.max_tokens,
+                              allowInlineFiles=a.allow_inline_files,
                               sampleQuestions=a.meta.sample_questions) for p in projects for a in p.assistants if
                   not a.id.startswith('_')]
 

--- a/fai-rag-app/fai-backend/fai_backend/new_chat/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/new_chat/service.py
@@ -54,4 +54,5 @@ class ChatStateService:
                                timestamp=chat_history_model.history[0].timestamp,
                                title=default_title,
                                max_tokens=chat_history_model.assistant.max_tokens,
+                               allow_inline_files=chat_history_model.assistant.allow_inline_files,
                                history=[convert_message(message) for message in chat_history_model.history])

--- a/fai-rag-app/fai-frontend/src/lib/components/chat/AttachedFile.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/chat/AttachedFile.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import SVG from '$lib/components/SVG.svelte'
+
+  export let title: string
+  export let onRemove: () => void
+  export let state: 'valid' | 'invalid' | 'pending'
+
+  const maxTitleLength = 15
+
+  $: shortTitle = title.length > maxTitleLength ? title.slice(0, maxTitleLength - 3) + '...' : title
+
+</script>
+
+<div class="p-1">
+  <div
+    class="flex items-center gap-2 p-2 bg-gray-800 text-white rounded relative"
+    class:bg-red-600={state === 'invalid'}
+    class:opacity-50={state === 'pending'}
+  >
+    <div
+      class="bg-orange-500 rounded w-8 h-8 flex items-center justify-center"
+      class:bg-red-500={state === 'invalid'}
+      class:bg-gray-500={state === 'pending'}
+    >
+      {#if state === 'invalid'}
+        <SVG
+          width="24"
+          src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNpcmNsZS14Ij48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIvPjxwYXRoIGQ9Im0xNSA5LTYgNiIvPjxwYXRoIGQ9Im05IDkgNiA2Ii8+PC9zdmc+"
+        />
+      {:else if state === 'pending'}
+        <SVG
+          width="24"
+          src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWVsbGlwc2lzIj48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxIi8+PGNpcmNsZSBjeD0iMTkiIGN5PSIxMiIgcj0iMSIvPjxjaXJjbGUgY3g9IjUiIGN5PSIxMiIgcj0iMSIvPjwvc3ZnPg=="
+        />
+      {:else}
+        <SVG
+          width="24"
+          src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWZpbGUtdGV4dCI+PHBhdGggZD0iTTE1IDJINmEyIDIgMCAwIDAtMiAydjE2YTIgMiAwIDAgMCAyIDJoMTJhMiAyIDAgMCAwIDItMlY3WiIvPjxwYXRoIGQ9Ik0xNCAydjRhMiAyIDAgMCAwIDIgMmg0Ii8+PHBhdGggZD0iTTEwIDlIOCIvPjxwYXRoIGQ9Ik0xNiAxM0g4Ii8+PHBhdGggZD0iTTE2IDE3SDgiLz48L3N2Zz4="
+        />
+      {/if}
+    </div>
+    <span class="break-keep">{shortTitle}</span>
+    <button
+      on:click={onRemove}
+      class="absolute -right-1 -top-1 w-5 h-5 bg-black text-xs flex items-center justify-center rounded-full"
+    >
+      X
+    </button>
+  </div>
+</div>

--- a/fai-rag-app/fai-frontend/src/lib/components/chat/SSEChat.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/chat/SSEChat.svelte
@@ -15,6 +15,7 @@
     description: string
     sampleQuestions: string[]
     maxTokens: number
+    allowInlineFiles: boolean
   }
 
   interface InitialState {
@@ -417,22 +418,28 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
       </div>
       <div class="w-full h-full" />
 
-      <div class="w-full h-full flex items-end">
-        <Button
-          on:click={showInlineFileDialog}
-          label=""
-          iconSrc="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXBhcGVyY2xpcCI+PHBhdGggZD0ibTIxLjQ0IDExLjA1LTkuMTkgOS4xOWE2IDYgMCAwIDEtOC40OS04LjQ5bDguNTctOC41N0E0IDQgMCAxIDEgMTggOC44NGwtOC41OSA4LjU3YTIgMiAwIDAgMS0yLjgzLTIuODNsOC40OS04LjQ4Ii8+PC9zdmc+"
-        />
-        <div class="hidden">
-          <input
-            bind:this={inlineFileInput}
-            type="file"
-            multiple
-            on:change={inlineFilesChanged}
+      {#if selectedAssistant?.allowInlineFiles}
+        <div class="w-full h-full flex items-end">
+          <Button
+            on:click={showInlineFileDialog}
+            label=""
+            iconSrc="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXBhcGVyY2xpcCI+PHBhdGggZD0ibTIxLjQ0IDExLjA1LTkuMTkgOS4xOWE2IDYgMCAwIDEtOC40OS04LjQ5bDguNTctOC41N0E0IDQgMCAxIDEgMTggOC44NGwtOC41OSA4LjU3YTIgMiAwIDAgMS0yLjgzLTIuODNsOC40OS04LjQ4Ii8+PC9zdmc+"
           />
+          <div class="hidden">
+            <input
+              bind:this={inlineFileInput}
+              type="file"
+              multiple
+              on:change={inlineFilesChanged}
+            />
+          </div>
         </div>
-      </div>
-      <div class="w-full h-full">
+      {/if}
+
+      <div
+        class="w-full h-full"
+        class:col-span-2={!selectedAssistant || !selectedAssistant.allowInlineFiles}
+      >
         <textarea
           name="message"
           bind:value={currentMessageInput}

--- a/fai-rag-app/fai-frontend/src/lib/components/chat/SSEChat.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/chat/SSEChat.svelte
@@ -6,6 +6,7 @@
   import { findLastIndex } from '../../../util/array'
   import TokenCounter from '$lib/components/chat/TokenCounter.svelte'
   import { type ChatMessage, type IncomingMessage, incomingMessageToChatMessage, SSE } from '$lib/components/chat/SSE'
+  import AttachedFile from '$lib/components/chat/AttachedFile.svelte'
 
   interface Assistant {
     id: string
@@ -21,6 +22,18 @@
     max_tokens: number
     history: IncomingMessage[]
   }
+
+  interface InlineFile {
+    file: File
+    status: 'parsing' | 'done' | 'error'
+    parsed_content: string | null
+  }
+
+  const inlineFileAttachedFileStatusStateMap = {
+    'parsing': 'pending',
+    'done': 'valid',
+    'error': 'invalid',
+  } as const
 
   export let assistants: Assistant[] = []
   export let initialState: InitialState | undefined
@@ -56,6 +69,36 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
     } else {
       messages = []
     }
+  }
+
+  function redactDocumentText(fullContent: string): string {
+    const beginMatcher = /\[BEGIN DOCUMENT (.*)]/
+    const match = beginMatcher.exec(fullContent)
+    if (match) {
+      const endTag = '\n[END DOCUMENT]\n'
+      const endIndex = fullContent.indexOf(endTag, match.index)
+      if (endIndex !== -1) {
+        const redacted = fullContent.slice(0, match.index)
+          + `[document ${match[1]}]`
+          + fullContent.slice(endIndex + endTag.length)
+        return redactDocumentText(redacted)
+      }
+    }
+    return fullContent
+  }
+
+  function getFullMessageInput(question: string) {
+    let fullQuestion = question
+
+    const fileIds = Object.keys(inlineFiles)
+    if (fileIds.length > 0) {
+      const combinedContent = fileIds
+        .map(id => `[BEGIN DOCUMENT ${inlineFiles[id].file.name}]\n${inlineFiles[id].parsed_content}\n[END DOCUMENT]`)
+        .join('\n\n')
+      fullQuestion = combinedContent + '\n\n' + fullQuestion
+    }
+
+    return fullQuestion
   }
 
   /** SSE */
@@ -98,8 +141,9 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
 
   function createSSE(question: string) {
     lastMessageErrored = false
-    sse.create(question, activeConversationId, selectedAssistant?.project, selectedAssistant?.id)
+    sse.create(getFullMessageInput(question), activeConversationId, selectedAssistant?.project, selectedAssistant?.id)
     currentMessageInput = ''
+    inlineFiles = {}
   }
 
   function closeSSE() {
@@ -109,9 +153,10 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
   /** Token Counting */
   let exceededTokenCount: false
   let tokenCounter: TokenCounter
-  $: activeConversationId && tokenCounter?.queueUpdateTokenCount(currentMessageInput, activeConversationId, selectedAssistantId)
-  $: messages && activeConversationId && tokenCounter?.queueUpdateTokenCount(currentMessageInput, activeConversationId, selectedAssistantId)
-  $: selectedAssistantId && tokenCounter?.queueUpdateTokenCount(currentMessageInput, activeConversationId, selectedAssistantId)
+  $: activeConversationId && tokenCounter?.queueUpdateTokenCount(getFullMessageInput(currentMessageInput), activeConversationId, selectedAssistantId)
+  $: messages && activeConversationId && tokenCounter?.queueUpdateTokenCount(getFullMessageInput(currentMessageInput), activeConversationId, selectedAssistantId)
+  $: selectedAssistantId && tokenCounter?.queueUpdateTokenCount(getFullMessageInput(currentMessageInput), activeConversationId, selectedAssistantId)
+  $: inlineFiles && tokenCounter?.queueUpdateTokenCount(getFullMessageInput(currentMessageInput), activeConversationId, selectedAssistantId)
 
   /** Scrolling */
   let contentScrollDiv: Element
@@ -141,6 +186,66 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
     scrollToBottom(contentScrollDiv)
   }
 
+  /** File inlining */
+  let inlineFileInput: HTMLInputElement
+  let inlineFiles: { [id: string]: InlineFile } = {}
+  let anyInvalidFiles: boolean = false
+  $: anyInvalidFiles = Object.keys(inlineFiles).some(i => inlineFiles[i].status !== 'done')
+
+  function parseInlineFile(id: string) {
+    if (!inlineFiles[id]) {
+      return
+    }
+
+    const formData = new FormData()
+    formData.append('file', inlineFiles[id].file)
+
+    inlineFiles[id].status = 'parsing'
+    fetch('/api/document/parse', {
+      method: 'POST',
+      body: formData,
+    }).then(r => {
+      if (!r.ok) {
+        throw Error(`${r.status} ${r.statusText}`)
+      }
+      return r.text()
+    })
+      .then(data => {
+        console.log('data', data)
+        inlineFiles[id].parsed_content = data
+        inlineFiles[id].status = 'done'
+      })
+      .catch(err => {
+        inlineFiles[id].status = 'error'
+        console.error(`failed to parse`, err, inlineFiles[id])
+      })
+  }
+
+  function showInlineFileDialog() {
+    inlineFileInput.click()
+  }
+
+  function inlineFilesChanged(ev: Event) {
+    const element = ev.currentTarget as HTMLInputElement
+    const files: File[] = element.files ? Array.from(element.files) : []
+    inlineFiles = files.reduce((acc, file) => ({
+      ...acc,
+      [`${file.name}_${file.lastModified}`]: {
+        file,
+        status: 'parsing',
+        parsed_content: null,
+      },
+    }), {})
+
+    Object.keys(inlineFiles).forEach(parseInlineFile)
+  }
+
+  function removeInlineFile(id: string) {
+    delete inlineFiles[id]
+    inlineFiles = { ...inlineFiles }
+  }
+
+
   /** Misc UI */
   function clearChat() {
     messages = []
@@ -151,12 +256,16 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
   function handleTextareaKeypress(event: KeyboardEvent) {
     if (event.key == 'Enter' && !event.shiftKey) {
       event.preventDefault()
-      if (!exceededTokenCount) createSSE(currentMessageInput)
+      if (!exceededTokenCount && !anyInvalidFiles) createSSE(currentMessageInput)
     }
   }
 
   function formatMessageForMarkdown(content: string): string {
     return content.replace(/\n/g, `\n\n  `)
+  }
+
+  function formatSelfMessage(content: string): string {
+    return redactDocumentText(content)
   }
 
   function askSampleQuestion(question: string) {
@@ -187,13 +296,13 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
 
 <div
   class="absolute bottom-0 top-16 grid w-full overflow-hidden lg:w-[calc(100%-20rem)]"
-  class:grid-rows-[6rem_1fr_7rem]={!initialState}
-  class:grid-rows-[1fr_7rem]={initialState}
+  class:grid-rows-[6rem_1fr_12rem]={!initialState}
+  class:grid-rows-[1fr_12rem]={initialState}
 >
   <!-- Floating controls -->
   <div
-    class="absolute inset-x-0 bottom-32 z-10 flex justify-center transition"
-    class:translate-y-20={isContentAtBottom}
+    class="absolute inset-x-0 bottom-52 z-10 flex justify-center transition"
+    class:translate-y-40={isContentAtBottom}
   >
     <button
       on:click={scrollContentToBottom}
@@ -235,7 +344,7 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
       {#each messages as message (message.id)}
         <ChatBubble
           content={message.isSelf
-            ? message.content
+            ? formatSelfMessage(message.content)
             : formatMessageForMarkdown(message.content)}
           isSelf={message.isSelf}
           enableMarkdown={!message.isSelf}
@@ -281,35 +390,66 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
   </div>
 
   <!-- Bottom controls -->
-  <div class="z-10 p-3">
-    <form class="h-full w-full" on:submit={scrollContentToBottom}>
-      <fieldset
-        disabled={(!selectedAssistantId || !!lastMessageErrored) && !initialState}
-        class="h-full"
-      >
-        <div class="flex h-full w-full items-end gap-2">
-          <div class="flex h-full w-full grow flex-col gap-1.5">
-            <TokenCounter
-              bind:this={tokenCounter}
-              maxTokens={initialState?.max_tokens ?? selectedAssistant?.maxTokens ?? -1}
-              bind:exceededTokenCount={exceededTokenCount}
+  <div class="z-10 p-3 bg-white">
+    <div
+      class="w-full max-w-full overflow-hidden h-full grid grid-cols-[auto_1fr_auto] grid-rows-[auto_auto_1fr] gap-1">
+      <div class="w-full h-full" />
+      <div class="w-full h-full">
+        <div class="flex gap-2 w-full">
+          {#each Object.keys(inlineFiles) as fileId}
+            <AttachedFile
+              title={inlineFiles[fileId].file.name}
+              onRemove={() => removeInlineFile(fileId)}
+              state={inlineFileAttachedFileStatusStateMap[inlineFiles[fileId].status]}
             />
-            <textarea
-              name="message"
-              bind:value={currentMessageInput}
-              on:keydown={handleTextareaKeypress}
-              class="textarea textarea-bordered h-full grow"
-              class:textarea-error={exceededTokenCount}
-            />
-          </div>
-          <Button
-            disabled={exceededTokenCount}
-            on:click={formButtonClick}
-            label=""
-            iconSrc={formButtonIcon}
+          {/each}
+        </div>
+      </div>
+      <div class="w-full h-full" />
+
+      <div class="w-full h-full" />
+      <div class="w-full h-full">
+        <TokenCounter
+          bind:this={tokenCounter}
+          maxTokens={initialState?.max_tokens ?? selectedAssistant?.maxTokens ?? -1}
+          bind:exceededTokenCount={exceededTokenCount}
+        />
+      </div>
+      <div class="w-full h-full" />
+
+      <div class="w-full h-full flex items-end">
+        <Button
+          on:click={showInlineFileDialog}
+          label=""
+          iconSrc="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXBhcGVyY2xpcCI+PHBhdGggZD0ibTIxLjQ0IDExLjA1LTkuMTkgOS4xOWE2IDYgMCAwIDEtOC40OS04LjQ5bDguNTctOC41N0E0IDQgMCAxIDEgMTggOC44NGwtOC41OSA4LjU3YTIgMiAwIDAgMS0yLjgzLTIuODNsOC40OS04LjQ4Ii8+PC9zdmc+"
+        />
+        <div class="hidden">
+          <input
+            bind:this={inlineFileInput}
+            type="file"
+            multiple
+            on:change={inlineFilesChanged}
           />
         </div>
-      </fieldset>
-    </form>
+      </div>
+      <div class="w-full h-full">
+        <textarea
+          name="message"
+          bind:value={currentMessageInput}
+          on:keydown={handleTextareaKeypress}
+          class="textarea textarea-bordered h-full w-full grow leading-tight"
+          placeholder="Message"
+          class:textarea-error={exceededTokenCount}
+        />
+      </div>
+      <div class="w-full h-full flex items-end">
+        <Button
+          disabled={exceededTokenCount || anyInvalidFiles}
+          on:click={formButtonClick}
+          label=""
+          iconSrc={formButtonIcon}
+        />
+      </div>
+    </div>
   </div>
 </div>

--- a/fai-rag-app/fai-frontend/src/lib/components/chat/SSEChat.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/chat/SSEChat.svelte
@@ -22,6 +22,7 @@
     chat_id: string
     max_tokens: number
     history: IncomingMessage[]
+    allow_inline_files: boolean
   }
 
   interface InlineFile {
@@ -190,8 +191,10 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
   /** File inlining */
   let inlineFileInput: HTMLInputElement
   let inlineFiles: { [id: string]: InlineFile } = {}
+  let allowInlineFiles = false
   let anyInvalidFiles: boolean = false
   $: anyInvalidFiles = Object.keys(inlineFiles).some(i => inlineFiles[i].status !== 'done')
+  $: allowInlineFiles = !!selectedAssistant?.allowInlineFiles || !!initialState?.allow_inline_files
 
   function parseInlineFile(id: string) {
     if (!inlineFiles[id]) {
@@ -418,7 +421,7 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
       </div>
       <div class="w-full h-full" />
 
-      {#if selectedAssistant?.allowInlineFiles}
+      {#if allowInlineFiles}
         <div class="w-full h-full flex items-end">
           <Button
             on:click={showInlineFileDialog}
@@ -438,7 +441,7 @@ By continuing to use Folkets AI, you confirm that you have read, understood, and
 
       <div
         class="w-full h-full"
-        class:col-span-2={!selectedAssistant || !selectedAssistant.allowInlineFiles}
+        class:col-span-2={!allowInlineFiles}
       >
         <textarea
           name="message"

--- a/fai-rag-app/fai-frontend/src/lib/components/chat/TokenCounter.svelte
+++ b/fai-rag-app/fai-frontend/src/lib/components/chat/TokenCounter.svelte
@@ -34,15 +34,21 @@
   }
 </script>
 
-<span
+<div
   class:hidden={maxTokens <= 0}
-  class="block text-right text-xs"
+  class="flex justify-between items-end"
 >
-  {#if tokenTimeoutHandle >= 0}
-    ...
-  {:else if tokenCount >= 0}
-    {tokenCount}/{maxTokens}
-  {:else}
-    ?
-  {/if}
-</span>
+  <div class="text-xs text-red-700 font-bold">
+    <span class:hidden={tokenCount <= maxTokens}>Message and/or file exceeds size limit</span>
+  </div>
+  <div class="text-xs flex">
+    {#if tokenTimeoutHandle >= 0}
+      <span>...</span>
+    {:else if tokenCount >= 0}
+      <span class:text-red-700={tokenCount > maxTokens}>{tokenCount}</span>
+      <span>/{maxTokens}</span>
+    {:else}
+      <span>?</span>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
Added support for uploading files directly in chat. Works by extracting document contents using new endpoint, and directly pasting the content into the beginning of the chat message. Some sugar for UI handling as well.

First, enable in assistant edit UI:

<img width="251" alt="image" src="https://github.com/user-attachments/assets/8f983be9-bd72-4ff7-b784-2fc78a68a2f6">

Then add files in chat and watch it go:

<img width="293" alt="image" src="https://github.com/user-attachments/assets/8517f459-b671-448d-8635-753b6d5456fe">
