### PR TITLE
Feat/collections editing

### DIFF
--- a/fai-rag-app/fai-backend/fai_backend/collection/models.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection/models.py
@@ -1,4 +1,12 @@
 from beanie import Document
+from pydantic import BaseModel
+
+
+class CollectionFile(BaseModel):
+    id: str
+    name: str
+    upload_timestamp: str
+    byte_size: int
 
 
 class CollectionMetadataModel(Document):
@@ -7,6 +15,7 @@ class CollectionMetadataModel(Document):
     description: str = ''
     embedding_model: str | None = ''
     urls: list[str] | None = None
+    files: list[CollectionFile] = []
 
     class Settings:
         name = 'collections'

--- a/fai-rag-app/fai-backend/fai_backend/collection/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection/service.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fai_backend.collection.models import CollectionMetadataModel
 from fai_backend.repositories import CollectionMetadataRepository, collection_metadata_repo
 from fai_backend.repository.query.component import AttributeAssignment
@@ -42,7 +44,24 @@ class CollectionService:
 
         return label
 
+    async def update_collection_metadata(self, collection_id: str, collection_metadata_patch: dict[str, Any]):
+        existing = await self.get_collection_metadata(collection_id)
+        if len(existing) <= 0:
+            return None
+
+        return await self.repo.update(str(existing[0].id), collection_metadata_patch)
+
     async def list_collection_ids(self) -> list[str]:
         collections = await self.repo.list()
         collections.reverse()
         return [c.collection_id for c in collections]
+
+    async def list_collections(self) -> list[CollectionMetadataModel]:
+        return await self.repo.list()
+
+    async def delete_collection(self, collection_id: str):
+        existing = await self.get_collection_metadata(collection_id)
+        if len(existing) <= 0:
+            return
+
+        return await self.repo.delete(str(existing[0].id))

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/dependencies.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/dependencies.py
@@ -1,0 +1,12 @@
+from fai_backend.collection_v2.service import CollectionService
+from fai_backend.files.dependecies import get_file_upload_service
+from fai_backend.repositories import collection_metadata_repo
+from fai_backend.vector.dependencies import get_vector_service
+
+
+async def get_collection_service() -> CollectionService:
+    return CollectionService(
+        repo=collection_metadata_repo,
+        vector_service=await get_vector_service(),
+        file_upload_service=get_file_upload_service()
+    )

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/routes.py
@@ -32,7 +32,7 @@ class CreateCollectionResponse(BaseModel):
     status_code=201,
     response_model=CreateCollectionResponse
 )
-async def create_collection(data: CreateCollectionRequest):
+async def create_collection(data: CreateCollectionRequest, _: ProjectUser = Depends(get_project_user)):
     service = await get_collection_service()
     new_collection = await service.create_collection(
         label=data.label,
@@ -62,7 +62,7 @@ class ListCollectionsResponse(BaseModel):
     summary='Get all collections',
     response_model=ListCollectionsResponse
 )
-async def list_collections():
+async def list_collections(_: ProjectUser = Depends(get_project_user)):
     service = await get_collection_service()
     all_collections = await service.get_collections()
     return ListCollectionsResponse(
@@ -84,7 +84,7 @@ class GetCollectionResponse(BaseModel):
 
 
 @router.get('/collections/{id}', summary='Get a single collection')
-async def get_collection(id: str):
+async def get_collection(id: str, _: ProjectUser = Depends(get_project_user)):
     service = await get_collection_service()
     collection = await service.get_collection(id)
 
@@ -119,7 +119,7 @@ class UpdateCollectionResponse(BaseModel):
     summary='Update a collection',
     response_model=UpdateCollectionResponse,
 )
-async def update_collection(id: str, data: UpdateCollectionRequest):
+async def update_collection(id: str, data: UpdateCollectionRequest, _: ProjectUser = Depends(get_project_user)):
     service = await get_collection_service()
     result = await service.update_collection(id, data.dict(exclude_none=True))
 
@@ -140,7 +140,7 @@ async def update_collection(id: str, data: UpdateCollectionRequest):
     summary='Delete a collection',
     status_code=204,
 )
-async def delete_collection(id: str):
+async def delete_collection(id: str, _: ProjectUser = Depends(get_project_user)):
     service = await get_collection_service()
     await service.delete_collection(id)
 

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/routes.py
@@ -1,0 +1,156 @@
+import uuid
+from typing import Union
+
+from fastapi import APIRouter, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from fai_backend.collection.dependencies import get_collection_service
+
+router = APIRouter(
+    prefix='/api',
+    tags=['Collections'],
+)
+
+
+class CreateCollectionRequest(BaseModel):
+    label: str
+    description: str
+    embedding_model: str
+
+
+class CreateCollectionResponse(BaseModel):
+    id: str
+    label: str
+    description: str
+    embedding_model: str
+
+
+@router.post(
+    '/collections',
+    summary='Create a new collection',
+    status_code=201,
+    response_model=CreateCollectionResponse
+)
+async def create_collection(data: CreateCollectionRequest):
+    service = get_collection_service()
+    new_collection = await service.create_collection_metadata(
+        collection_id=str(uuid.uuid4()),
+        label=data.label,
+        description=data.description,
+        embedding_model=data.embedding_model
+    )
+    return CreateCollectionResponse(
+        id=new_collection.collection_id,
+        label=new_collection.label,
+        description=new_collection.description,
+        embedding_model=new_collection.embedding_model
+    )
+
+
+class ListCollectionsEntry(BaseModel):
+    id: str
+    label: str
+    description: str
+
+
+class ListCollectionsResponse(BaseModel):
+    data: list[ListCollectionsEntry]
+
+
+@router.get(
+    '/collections',
+    summary='Get all collections',
+    response_model=ListCollectionsResponse
+)
+async def list_collections():
+    service = get_collection_service()
+    all_collections = await service.list_collections()
+    return ListCollectionsResponse(
+        data=[ListCollectionsEntry(
+            id=collection.collection_id,
+            label=collection.label,
+            description=collection.description
+        ) for
+            collection in all_collections]
+    )
+
+
+class GetCollectionResponse(BaseModel):
+    id: str
+    label: str
+    description: str
+    embedding_model: str
+    urls: list[str]
+
+
+@router.get('/collections/{id}', summary='Get a single collection')
+async def get_collection(id: str):
+    service = get_collection_service()
+    collections = await service.get_collection_metadata(id)
+
+    if len(collections) == 0:
+        raise HTTPException(status_code=404, detail='Collection not found')
+
+    return GetCollectionResponse(
+        id=collections[0].collection_id,
+        label=collections[0].label,
+        description=collections[0].description,
+        embedding_model=collections[0].embedding_model,
+        urls=collections[0].urls or []
+    )
+
+
+class UpdateCollectionRequest(BaseModel):
+    label: Union[str, None] = None
+    description: Union[str, None] = None
+    embedding_model: Union[str, None] = None
+    urls: Union[list[str], None] = None
+
+
+class UpdateCollectionResponse(BaseModel):
+    id: str
+    label: str
+    description: str
+    embedding_model: str
+    urls: list[str]
+
+
+@router.patch(
+    '/collections/{id}',
+    summary='Update a collection',
+    response_model=UpdateCollectionResponse,
+)
+async def update_collection(id: str, data: UpdateCollectionRequest):
+    service = get_collection_service()
+    result = await service.update_collection_metadata(id, data.dict(exclude_none=True))
+
+    if result is None:
+        raise HTTPException(status_code=404, detail='Collection not found')
+
+    return UpdateCollectionResponse(
+        id=result.collection_id,
+        label=result.label,
+        description=result.description,
+        embedding_model=result.embedding_model,
+        urls=result.urls or []
+    )
+
+
+@router.delete(
+    '/collections/{id}',
+    summary='Delete a collection',
+    status_code=204,
+)
+async def delete_collection(id: str):
+    service = get_collection_service()
+    await service.delete_collection(id)
+
+
+@router.put('/collections/{id}/files', summary='Replace collection files')
+async def list_collection_files(id: str, files: list[UploadFile]):
+    raise NotImplementedError()
+
+
+@router.delete('/collections/{collection_id}/files/{file_id}', summary='Delete a file')
+async def delete_collection_file(collection_id: str, file_id: str):
+    raise NotImplementedError()

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/routes.py
@@ -1,19 +1,11 @@
-import uuid
-from datetime import datetime
 from typing import Union
-from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException, UploadFile, Depends
-from more_itertools import chunked
 from pydantic import BaseModel
 
-from fai_backend.collection.dependencies import get_collection_service
-from fai_backend.collection.models import CollectionFile
+from fai_backend.collection_v2.dependencies import get_collection_service
 from fai_backend.dependencies import get_project_user
-from fai_backend.files.dependecies import get_file_upload_service
-from fai_backend.files.file_parser import ParserFactory
 from fai_backend.schema import ProjectUser
-from fai_backend.vector.dependencies import get_vector_service
 
 router = APIRouter(
     prefix='/api',
@@ -41,17 +33,8 @@ class CreateCollectionResponse(BaseModel):
     response_model=CreateCollectionResponse
 )
 async def create_collection(data: CreateCollectionRequest):
-    new_id = str(uuid.uuid4())
-
-    vector_service = await get_vector_service()
-    await vector_service.create_collection(
-        collection_name=new_id,
-        embedding_model=data.embedding_model,
-    )
-
-    collection_service = get_collection_service()
-    new_collection = await collection_service.create_collection_metadata(
-        collection_id=new_id,
+    service = await get_collection_service()
+    new_collection = await service.create_collection(
         label=data.label,
         description=data.description,
         embedding_model=data.embedding_model
@@ -80,8 +63,8 @@ class ListCollectionsResponse(BaseModel):
     response_model=ListCollectionsResponse
 )
 async def list_collections():
-    service = get_collection_service()
-    all_collections = await service.list_collections()
+    service = await get_collection_service()
+    all_collections = await service.get_collections()
     return ListCollectionsResponse(
         data=[ListCollectionsEntry(
             id=collection.collection_id,
@@ -102,18 +85,18 @@ class GetCollectionResponse(BaseModel):
 
 @router.get('/collections/{id}', summary='Get a single collection')
 async def get_collection(id: str):
-    service = get_collection_service()
-    collections = await service.get_collection_metadata(id)
+    service = await get_collection_service()
+    collection = await service.get_collection(id)
 
-    if len(collections) == 0:
+    if collection is None:
         raise HTTPException(status_code=404, detail='Collection not found')
 
     return GetCollectionResponse(
-        id=collections[0].collection_id,
-        label=collections[0].label,
-        description=collections[0].description,
-        embedding_model=collections[0].embedding_model,
-        urls=collections[0].urls or []
+        id=collection.collection_id,
+        label=collection.label,
+        description=collection.description,
+        embedding_model=collection.embedding_model,
+        urls=collection.urls or []
     )
 
 
@@ -121,7 +104,6 @@ class UpdateCollectionRequest(BaseModel):
     label: Union[str, None] = None
     description: Union[str, None] = None
     embedding_model: Union[str, None] = None
-    urls: Union[list[str], None] = None
 
 
 class UpdateCollectionResponse(BaseModel):
@@ -129,6 +111,7 @@ class UpdateCollectionResponse(BaseModel):
     label: str
     description: str
     embedding_model: str
+    urls: list[str]
 
 
 @router.patch(
@@ -137,8 +120,8 @@ class UpdateCollectionResponse(BaseModel):
     response_model=UpdateCollectionResponse,
 )
 async def update_collection(id: str, data: UpdateCollectionRequest):
-    service = get_collection_service()
-    result = await service.update_collection_metadata(id, data.dict(exclude_none=True))
+    service = await get_collection_service()
+    result = await service.update_collection(id, data.dict(exclude_none=True))
 
     if result is None:
         raise HTTPException(status_code=404, detail='Collection not found')
@@ -158,28 +141,8 @@ async def update_collection(id: str, data: UpdateCollectionRequest):
     status_code=204,
 )
 async def delete_collection(id: str):
-    service = get_collection_service()
+    service = await get_collection_service()
     await service.delete_collection(id)
-
-
-def generate_chunks(file_paths_or_urls: list[str]):
-    for file_or_url in file_paths_or_urls:
-        for element in ParserFactory.get_parser(file_or_url).parse(file_or_url):
-            if len(element.text):
-                yield {
-                    'document': element.text,
-                    'document_meta': {
-                        key: value
-                        for key, value in element.metadata.to_dict().items()
-                        if key in ['filename', 'url', 'page_number', 'page_name']
-                    },
-                    'document_id': element.id
-                }
-
-
-def is_url(string: str) -> bool:
-    parsed = urlparse(string)
-    return parsed.scheme in {'http', 'https'}
 
 
 @router.put('/collections/{id}/files', summary='Replace collection files')
@@ -189,53 +152,13 @@ async def set_collection_files(
         urls: list[str] = None,
         project_user: ProjectUser = Depends(get_project_user)
 ):
-    files = files or []
-    urls = urls or []
-    collection_service = get_collection_service()
-    vector_service = await get_vector_service()
-
-    collection = next((c for c in await collection_service.get_collection_metadata(id)), None)
-
-    if collection is None:
-        raise HTTPException(status_code=404, detail='Collection not found')
-
+    service = await get_collection_service()
     try:
-        await vector_service.delete_collection(id)
-    except ValueError:
-        pass
-
-    await vector_service.create_collection(
-        collection_name=id,
-        embedding_model=collection.embedding_model
-    )
-
-    file_service = get_file_upload_service()
-    upload_path = file_service.save_files(project_user.project_id, files)
-    list_of_urls = [url for url in urls if is_url(url)]
-    for batch in chunked(
-            generate_chunks([
-                *[file.path for file in file_service.get_file_infos(upload_path)],
-                *list_of_urls
-            ]),
-            100
-    ):
-        await vector_service.add_documents_without_id_to_empty_collection(
-            collection_name=id,
-            documents=[chunk['document'] for chunk in batch],
-            embedding_model=collection.embedding_model,
-            documents_metadata=[chunk['document_meta'] for chunk in batch],
-            document_ids=[chunk['document_id'] for chunk in batch]
+        await service.set_collection_files(
+            collection_id=id,
+            project_id=project_user.project_id,
+            files=files,
+            urls=urls
         )
-
-    now_timestamp = datetime.utcnow().isoformat()
-    collection_files = [
-        CollectionFile(
-            id=str(uuid.uuid4()),
-            name=file.filename,
-            upload_timestamp=now_timestamp,
-            byte_size=file.size or 0
-        )
-        for file in files
-    ]
-
-    await collection_service.update_collection_metadata(id, {'files': collection_files, 'urls': list_of_urls})
+    except LookupError:
+        raise HTTPException(status_code=404, detail='Collection not found')

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/routes.py
@@ -145,8 +145,8 @@ async def delete_collection(id: str, _: ProjectUser = Depends(get_project_user))
     await service.delete_collection(id)
 
 
-@router.put('/collections/{id}/files', summary='Replace collection files')
-async def set_collection_files(
+@router.put('/collections/{id}/content', summary='Replace collection content')
+async def set_collection_content(
         id: str,
         files: list[UploadFile] = None,
         urls: list[str] = None,

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/service.py
@@ -67,7 +67,7 @@ class CollectionService:
             files: list[UploadFile] = None,
             urls: list[str] = None,
     ):
-        files = files or []
+        files = [f for f in (files or []) if f.size > 0]
         urls = urls or []
 
         collection = await self.get_collection(collection_id)

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/service.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/service.py
@@ -1,0 +1,162 @@
+import uuid
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi import UploadFile
+from more_itertools import chunked
+
+from fai_backend.collection.models import CollectionMetadataModel, CollectionFile
+from fai_backend.files.file_parser import ParserFactory
+from fai_backend.files.service import FileUploadService
+from fai_backend.repositories import CollectionMetadataRepository
+from fai_backend.repository.query.component import AttributeAssignment
+from fai_backend.vector.service import VectorService
+
+
+class CollectionService:
+    def __init__(
+            self,
+            repo: CollectionMetadataRepository,
+            vector_service: VectorService,
+            file_upload_service: FileUploadService
+    ):
+        self.repo = repo
+        self.vector_service = vector_service
+        self.file_upload_service = file_upload_service
+
+    async def create_collection(self, label: str, description: str, embedding_model: str) -> CollectionMetadataModel:
+        new_id = str(uuid.uuid4())
+
+        await self.vector_service.create_collection(
+            collection_name=new_id,
+            embedding_model=embedding_model,
+        )
+
+        new_collection = await self._create_collection_metadata(
+            collection_id=new_id,
+            label=label,
+            description=description,
+            embedding_model=embedding_model
+        )
+
+        return new_collection
+
+    async def get_collections(self) -> list[CollectionMetadataModel]:
+        return await self.repo.list()
+
+    async def get_collection(self, collection_id: str) -> CollectionMetadataModel | None:
+        query = AttributeAssignment('collection_id', collection_id)
+
+        result = await self.repo.list(query)
+
+        return result[0] if len(result) > 0 else None
+
+    async def update_collection(self, collection_id: str,
+                                collection_metadata_patch: dict[str, Any]) -> CollectionMetadataModel | None:
+        existing = await self.get_collection(collection_id)
+        if existing is None:
+            return None
+
+        return await self.repo.update(str(existing.id), collection_metadata_patch)
+
+    async def set_collection_files(
+            self,
+            collection_id: str,
+            project_id: str,
+            files: list[UploadFile] = None,
+            urls: list[str] = None,
+    ):
+        files = files or []
+        urls = urls or []
+
+        collection = await self.get_collection(collection_id)
+
+        if collection is None:
+            raise LookupError('Collection not found')
+
+        try:
+            await self.vector_service.delete_collection(collection_id)
+        except ValueError:
+            pass
+
+        await self.vector_service.create_collection(
+            collection_name=collection_id,
+            embedding_model=collection.embedding_model
+        )
+
+        upload_path = self.file_upload_service.save_files(project_id, files)
+        list_of_urls = [url for url in urls if CollectionService._is_url(url)]
+        for batch in chunked(
+                CollectionService._generate_chunks([
+                    *[file.path for file in self.file_upload_service.get_file_infos(upload_path)],
+                    *list_of_urls
+                ]),
+                100
+        ):
+            await self.vector_service.add_documents_without_id_to_empty_collection(
+                collection_name=collection_id,
+                documents=[chunk['document'] for chunk in batch],
+                embedding_model=collection.embedding_model,
+                documents_metadata=[chunk['document_meta'] for chunk in batch],
+                document_ids=[chunk['document_id'] for chunk in batch]
+            )
+
+        now_timestamp = datetime.utcnow().isoformat()
+        collection_files = [
+            CollectionFile(
+                id=str(uuid.uuid4()),
+                name=file.filename,
+                upload_timestamp=now_timestamp,
+                byte_size=file.size or 0
+            )
+            for file in files
+        ]
+
+        await self.update_collection(collection_id, {'files': collection_files, 'urls': list_of_urls})
+
+    async def delete_collection(self, collection_id: str):
+        existing = await self.get_collection(collection_id)
+        if existing is None:
+            return
+
+        await self.repo.delete(str(existing.id))
+
+    async def _create_collection_metadata(
+            self,
+            collection_id: str,
+            label: str,
+            description: str = '',
+            embedding_model: str | None = None,
+            urls: list[str] | None = None
+
+    ):
+        collection_metadata = CollectionMetadataModel(
+            collection_id=collection_id,
+            label=label,
+            description=description,
+            embedding_model=embedding_model,
+            urls=urls
+        )
+
+        return await self.repo.create(collection_metadata)
+
+    @staticmethod
+    def _is_url(string: str) -> bool:
+        parsed = urlparse(string)
+        return parsed.scheme in {'http', 'https'}
+
+    @staticmethod
+    def _generate_chunks(file_paths_or_urls: list[str]):
+        for file_or_url in file_paths_or_urls:
+            for element in ParserFactory.get_parser(file_or_url).parse(file_or_url):
+                if len(element.text):
+                    yield {
+                        'document': element.text,
+                        'document_meta': {
+                            key: value
+                            for key, value in element.metadata.to_dict().items()
+                            if key in ['filename', 'url', 'page_number', 'page_name']
+                        },
+                        'document_id': element.id
+                    }

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/view_routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/view_routes.py
@@ -6,7 +6,7 @@ from pydantic import ByteSize
 from fai_backend.collection.models import CollectionMetadataModel, CollectionFile
 from fai_backend.collection_v2.dependencies import get_collection_service
 from fai_backend.collection_v2.routes import UpdateCollectionRequest, update_collection, delete_collection, \
-    set_collection_files, CreateCollectionRequest, create_collection
+    set_collection_content, CreateCollectionRequest, create_collection
 from fai_backend.config import settings
 from fai_backend.dependencies import get_page_template_for_logged_in_users, get_project_user
 from fai_backend.framework.display import DisplayAs
@@ -136,8 +136,8 @@ def get_collection_metadata_form(collection: CollectionMetadataModel | None, sub
                     *([c.Div(
                         components=[
                             c.Link(
-                                text=_('Edit Documents/URLs'),
-                                url=f'/view/collections/{collection.collection_id}/files',
+                                text=_('Edit Collection Content'),
+                                url=f'/view/collections/{collection.collection_id}/content',
                                 state='primary'
                             )
                         ]
@@ -153,8 +153,8 @@ class CollectionFileViewItem(CollectionFile):
     friendly_timestamp: str
 
 
-@router.get('/collections/{collection_id}/files', response_model=list, response_model_exclude_none=True)
-async def get_collection_files_view(collection_id, view=Depends(get_page_template_for_logged_in_users)):
+@router.get('/collections/{collection_id}/content', response_model=list, response_model_exclude_none=True)
+async def get_collection_content_view(collection_id, view=Depends(get_page_template_for_logged_in_users)):
     service = await get_collection_service()
     collection = await service.get_collection(collection_id)
     if not collection:
@@ -181,7 +181,7 @@ async def get_collection_files_view(collection_id, view=Depends(get_page_templat
                     c.Heading(text='Replace existing content', level=1, class_name='my-5 font-bold'),
                     c.Form(
                         submit_as='form',
-                        submit_url=f'/api/view/collections/{collection_id}/files',
+                        submit_url=f'/api/view/collections/{collection_id}/content',
                         components=[
                             c.Textarea(
                                 name='urls',
@@ -283,26 +283,26 @@ async def update_collection_from_view(
 
 
 @router.post(
-    '/collections/{collection_id}/files',
-    summary='Replace collection files/URLs (called from views)',
+    '/collections/{collection_id}/content',
+    summary='Replace collection content (Files/URLs) (called from views)',
     response_model=list,
     response_model_exclude_none=True
 )
-async def replace_collection_files_from_view(
+async def replace_collection_content_from_view(
         collection_id: str,
         files: list[UploadFile] = None,
         urls: list[str] = None,
         view=Depends(get_page_template_for_logged_in_users),
         project_user: ProjectUser = Depends(get_project_user)
 ):
-    await set_collection_files(
+    await set_collection_content(
         collection_id,
         files,
         urls,
         project_user
     )
     return view(
-        [c.FireEvent(event=e.GoToEvent(url=f'/view/collections/{collection_id}/files'))],
+        [c.FireEvent(event=e.GoToEvent(url=f'/view/collections/{collection_id}/content'))],
         _('')
     )
 

--- a/fai-rag-app/fai-backend/fai_backend/collection_v2/view_routes.py
+++ b/fai-rag-app/fai-backend/fai_backend/collection_v2/view_routes.py
@@ -1,0 +1,324 @@
+from datetime import datetime
+
+from fastapi import Depends, APIRouter, UploadFile
+from pydantic import ByteSize
+
+from fai_backend.collection.models import CollectionMetadataModel, CollectionFile
+from fai_backend.collection_v2.dependencies import get_collection_service
+from fai_backend.collection_v2.routes import UpdateCollectionRequest, update_collection, delete_collection, \
+    set_collection_files, CreateCollectionRequest, create_collection
+from fai_backend.config import settings
+from fai_backend.dependencies import get_page_template_for_logged_in_users, get_project_user
+from fai_backend.framework.display import DisplayAs
+from fai_backend.framework.table import DataColumn
+from fai_backend.phrase import phrase as _
+from fai_backend.framework import components as c
+from fai_backend.framework import events as e
+from fai_backend.schema import ProjectUser
+
+router = APIRouter(
+    prefix='/api/view',
+    tags=['Collections'],
+)
+
+
+class CollectionViewItem(CollectionMetadataModel):
+    delete_label: str = "Delete"  # TODO: Hacky
+
+
+@router.get('/collections', response_model=list, response_model_exclude_none=True)
+async def get_collections_view(view=Depends(get_page_template_for_logged_in_users)):
+    service = await get_collection_service()
+    all_collections = await service.get_collections()
+    all_collections = [CollectionViewItem(**col.model_dump()) for col in all_collections]
+    return view(
+        [
+            c.DataTable(
+                data=all_collections,
+                columns=[
+                    DataColumn(
+                        key='label',
+                        id='label',
+                        label='Name',
+                    ),
+                    DataColumn(
+                        key='collection_id',
+                        id='collection_id',
+                        label='ID',
+                        display=DisplayAs.link,
+                        on_click=e.GoToEvent(url='/view/collections/{collection_id}'),
+                    ),
+                    DataColumn(
+                        key='description',
+                        id='description',
+                        label='Description',
+                    ),
+                    DataColumn(
+                        key='delete_label',
+                        id='delete',
+                        label='Delete',
+                        display=DisplayAs.link,
+                        on_click=e.GoToEvent(url='/view/collections/{collection_id}/delete'),
+                    )
+                ],
+                include_view_action=False
+            )
+        ],
+        _('collections', 'Collections')
+    )
+
+
+@router.get('/collections/create', response_model=list, response_model_exclude_none=True)
+async def get_create_collection_view(view=Depends(get_page_template_for_logged_in_users)):
+    return view(
+        [
+            c.Div(components=get_collection_metadata_form(None, '/api/view/collections'))
+        ],
+        _('Create Collection')
+    )
+
+
+@router.get('/collections/{collection_id}', response_model=list, response_model_exclude_none=True)
+async def get_collection_view(collection_id, view=Depends(get_page_template_for_logged_in_users)):
+    service = await get_collection_service()
+    collection = await service.get_collection(collection_id)
+    if not collection:
+        return [c.FireEvent(event=e.GoToEvent(url='/view/collections'))]
+    return view(
+        [
+            c.Div(components=get_collection_metadata_form(collection,
+                                                          f'/api/view/collections/{collection_id}'))
+        ],
+        _('collection', 'Collection')
+    )
+
+
+def get_collection_metadata_form(collection: CollectionMetadataModel | None, submit_url: str):
+    return [c.Div(components=[
+        c.Div(components=[
+            c.Text(text=f'Editing collection {collection.collection_id}' if collection else 'Create new collection'),
+            c.Form(
+                id=f'assistant-form-{collection.id}' if collection else 'assistant-form',
+                submit_url=submit_url,
+                method='POST',
+                submit_text=_('create_question_submit_button', 'Submit'),
+                components=[
+                    c.InputField(
+                        name='label',
+                        label=_('Name'),
+                        placeholder=_('Name'),
+                        required=True,
+                        html_type='text',
+                        size='sm',
+                        value=collection.label if collection else '',
+                    ),
+                    c.InputField(
+                        name='description',
+                        label=_('Description'),
+                        placeholder=_('Description'),
+                        required=False,
+                        html_type='text',
+                        size='sm',
+                        value=collection.description if collection else '',
+                    ),
+                    c.Select(
+                        name='embedding_model',
+                        label=_('Embedding model'),
+                        placeholder=_('Select embedding model'),
+                        required=True,
+                        options=[
+                            ('default', 'Default'),
+                            ('text-embedding-3-small', 'text-embedding-3-small')
+                        ],
+                        value=collection.embedding_model if collection else 'default',
+                        size='sm',
+                    ),
+                    *([c.Div(
+                        components=[
+                            c.Link(
+                                text=_('Edit Documents/URLs'),
+                                url=f'/view/collections/{collection.collection_id}/files',
+                                state='primary'
+                            )
+                        ]
+                    )] if collection else []),
+                ],
+            )
+        ], class_name='card-body'),
+    ], class_name='card')]
+
+
+class CollectionFileViewItem(CollectionFile):
+    friendly_byte_size: str
+    friendly_timestamp: str
+
+
+@router.get('/collections/{collection_id}/files', response_model=list, response_model_exclude_none=True)
+async def get_collection_files_view(collection_id, view=Depends(get_page_template_for_logged_in_users)):
+    service = await get_collection_service()
+    collection = await service.get_collection(collection_id)
+    if not collection:
+        return [c.FireEvent(event=e.GoToEvent(url='/view/collections'))]
+
+    def to_friendly_bytes(byte_size: int) -> str:
+        return ByteSize(byte_size).human_readable()
+
+    def to_friendly_timestamp(timestamp: str) -> str:
+        return datetime.fromisoformat(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+
+    viewable_files = [
+        CollectionFileViewItem(
+            **f.model_dump(),
+            friendly_byte_size=to_friendly_bytes(f.byte_size),
+            friendly_timestamp=to_friendly_timestamp(f.upload_timestamp)
+        ) for f in collection.files]
+
+    return view(
+        [
+            c.Div(
+                components=[
+                    c.Text(text=f'Showing content for collection "{collection.label}"'),
+                    c.Heading(text='Replace existing content', level=1, class_name='my-5 font-bold'),
+                    c.Form(
+                        submit_as='form',
+                        submit_url=f'/api/view/collections/{collection_id}/files',
+                        components=[
+                            c.Textarea(
+                                name='urls',
+                                placeholder=_('urls', 'URLs'),
+                                label=_('urls', 'URLs'),
+                                required=False,
+                                class_name='whitespace-nowrap',
+                                rows=6
+                            ),
+                            c.FileInput(
+                                name='files',
+                                label=_('file', 'File'),
+                                required=False,
+                                multiple=True,
+                                file_size_limit=settings.FILE_SIZE_LIMIT,
+                            ),
+                            c.Button(
+                                html_type='submit',
+                                label=_('replace', 'Replace'),
+                                class_name='btn btn-primary',
+                            ),
+                        ],
+                        class_name='card-body',
+                    ),
+                    c.Heading(text='Current content', level=1, class_name='mt-5 font-bold'),
+                    c.Heading(text='URLs', level=2, class_name=' mt-2 font-bold'),
+                    c.Table(
+                        data=[{'url': url} for url in collection.urls] if collection.urls else [],
+                        columns=[
+                            {'key': 'url', 'label': 'URL'}
+                        ]
+                    ),
+                    c.Heading(text='Files', level=2, class_name='mt-2 font-bold'),
+                    c.DataTable(
+                        data=viewable_files,
+                        columns=[
+                            DataColumn(
+                                key='name',
+                                id='name',
+                                label='Name',
+                            ),
+                            DataColumn(
+                                key='friendly_timestamp',
+                                id='friendly_timestamp',
+                                label='Timestamp',
+                            ),
+                            DataColumn(
+                                key='friendly_byte_size',
+                                id='friendly_byte_size',
+                                label='Size',
+                            )
+                        ],
+                        include_view_action=False
+                    )
+                ],
+                class_name='card-body',
+            )
+        ]
+        ,
+        _('collection content', 'Collection Content')
+    )
+
+
+# WRAPPER ENDPOINTS FOR FRONTEND
+
+@router.post(
+    '/collections',
+    summary='Create a new collection (called from views)',
+    response_model=list,
+    response_model_exclude_none=True
+)
+async def create_collection_from_view(
+        data: CreateCollectionRequest,
+        view=Depends(get_page_template_for_logged_in_users)
+):
+    result = await create_collection(data)
+    return view(
+        [c.FireEvent(event=e.GoToEvent(url=f'/view/collections/{result.id}'))],
+        _('')
+    )
+
+
+@router.post(
+    '/collections/{collection_id}',
+    summary='Update a collection (called from views)',
+    response_model=list,
+    response_model_exclude_none=True
+)
+async def update_collection_from_view(
+        collection_id: str,
+        data: UpdateCollectionRequest,
+        view=Depends(get_page_template_for_logged_in_users)
+):
+    await update_collection(collection_id, data)
+    return view(
+        [c.FireEvent(event=e.GoToEvent(url='/view/collections/'))],
+        _('')
+    )
+
+
+@router.post(
+    '/collections/{collection_id}/files',
+    summary='Replace collection files/URLs (called from views)',
+    response_model=list,
+    response_model_exclude_none=True
+)
+async def replace_collection_files_from_view(
+        collection_id: str,
+        files: list[UploadFile] = None,
+        urls: list[str] = None,
+        view=Depends(get_page_template_for_logged_in_users),
+        project_user: ProjectUser = Depends(get_project_user)
+):
+    await set_collection_files(
+        collection_id,
+        files,
+        urls,
+        project_user
+    )
+    return view(
+        [c.FireEvent(event=e.GoToEvent(url=f'/view/collections/{collection_id}/files'))],
+        _('')
+    )
+
+
+@router.get(
+    '/collections/{collection_id}/delete',
+    summary='Delete a collection (called from views)',
+    response_model=list,
+    response_model_exclude_none=True
+)
+async def delete_collection_from_view(
+        collection_id: str,
+        view=Depends(get_page_template_for_logged_in_users),
+):
+    await delete_collection(collection_id)
+    return view(
+        [c.FireEvent(event=e.GoToEvent(url='/view/collections/'))],
+        _('')
+    )

--- a/fai-rag-app/fai-backend/fai_backend/documents/menu.py
+++ b/fai-rag-app/fai-backend/fai_backend/documents/menu.py
@@ -1,4 +1,5 @@
 from fai_backend.framework import components as c
+from fai_backend.icons import icons
 from fai_backend.phrase import phrase as _
 from fai_backend.views import permission_required
 
@@ -7,22 +8,24 @@ from fai_backend.views import permission_required
 def menu_items() -> list:
     return [
         c.Menu(
-            title=_('documents', 'Documents'),
-            id='documents-menu',
+            title=_('collections', 'Collections'),
+            id='collections-menu',
             variant='vertical',
             sub_menu=True,
+            icon_src='data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWZpbGUtdGV4dCI+PHBhdGggZD0iTTE1IDJINmEyIDIgMCAwIDAtMiAydjE2YTIgMiAwIDAgMCAyIDJoMTJhMiAyIDAgMCAwIDItMlY3WiIvPjxwYXRoIGQ9Ik0xNCAydjRhMiAyIDAgMCAwIDIgMmg0Ii8+PHBhdGggZD0iTTEwIDlIOCIvPjxwYXRoIGQ9Ik0xNiAxM0g4Ii8+PHBhdGggZD0iTTE2IDE3SDgiLz48L3N2Zz4=',
+            class_name='collections-menu',
             components=[
                 c.Link(
-                    text=_('show_all', 'Show all'),
-                    url='/documents',
-                    active='/documents'
+                    text=_('show_all', 'Visa alla'),
+                    url='/view/collections',
+                    active='/view/collections*'
                 ),
                 c.Link(
-                    text=_('upload_new', 'Upload new'),
-                    url='/documents/upload',
-                    active='/documents/upload'
+                    text=_('Add new Collection'),
+                    url='/view/collections/create',
+                    active='/view/collections/create',
+                    icon_src=icons['plus'],
                 ),
             ],
-            icon_src='data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWZpbGUtdGV4dCI+PHBhdGggZD0iTTE1IDJINmEyIDIgMCAwIDAtMiAydjE2YTIgMiAwIDAgMCAyIDJoMTJhMiAyIDAgMCAwIDItMlY3WiIvPjxwYXRoIGQ9Ik0xNCAydjRhMiAyIDAgMCAwIDIgMmg0Ii8+PHBhdGggZD0iTTEwIDlIOCIvPjxwYXRoIGQ9Ik0xNiAxM0g4Ii8+PHBhdGggZD0iTTE2IDE3SDgiLz48L3N2Zz4='
-        ),
+        )
     ]

--- a/fai-rag-app/fai-backend/fai_backend/main.py
+++ b/fai-rag-app/fai-backend/fai_backend/main.py
@@ -23,6 +23,7 @@ from fai_backend.schema import ProjectUser
 from fai_backend.settings.routes import router as config_router
 from fai_backend.setup import setup_db, setup_project, setup_sentry, setup_file_parser, setup_settings
 from fai_backend.collection_v2.routes import router as collection_router
+from fai_backend.collection_v2.view_routes import router as collection_view_router
 
 
 @asynccontextmanager
@@ -55,6 +56,7 @@ app.include_router(documents_router)
 app.include_router(assistant_router)
 app.include_router(config_router)
 app.include_router(collection_router)
+app.include_router(collection_view_router)
 
 app.middleware('http')(add_git_revision_to_request_header)
 app.middleware('http')(remove_trailing_slash)

--- a/fai-rag-app/fai-backend/fai_backend/main.py
+++ b/fai-rag-app/fai-backend/fai_backend/main.py
@@ -22,6 +22,7 @@ from fai_backend.qaf.routes import router as qaf_router
 from fai_backend.schema import ProjectUser
 from fai_backend.settings.routes import router as config_router
 from fai_backend.setup import setup_db, setup_project, setup_sentry, setup_file_parser, setup_settings
+from fai_backend.collection_v2.routes import router as collection_router
 
 
 @asynccontextmanager
@@ -53,6 +54,7 @@ app.include_router(new_chat_router)
 app.include_router(documents_router)
 app.include_router(assistant_router)
 app.include_router(config_router)
+app.include_router(collection_router)
 
 app.middleware('http')(add_git_revision_to_request_header)
 app.middleware('http')(remove_trailing_slash)


### PR DESCRIPTION
Managing collections through API and frontend.

- [x] Basic CRUD API
- [x] Support URLs ~~(supply in `PUT set_collection_files` as FormData seems dirty? But can't mix FormData (for binary files) and JSON (more appropriate for URLs) in the same endpoint. Or separate endpoint, but how to merge with existing collection content instead of destroying and recreating entire collection?)~~ Done as FormData for now
- [x] Administration UI
- [x] Secure endpoints (hacky way for now)

## Guide

Menu entries (replaces "Documents")
<img width="671" alt="image" src="https://github.com/user-attachments/assets/fe359257-4e5b-45ea-9b0a-5d31f167be82" />

### Add new collection
Click "Add new Collection" and fill form:
<img width="456" alt="image" src="https://github.com/user-attachments/assets/0190d2d0-6f69-4f41-9e84-9d879f872b78" />

### Edit collection metadata
Page will refresh and the collection can be re-edited:
<img width="480" alt="image" src="https://github.com/user-attachments/assets/694a255f-5b3f-44b1-930f-3d6598821fe8" />

### Add files/URLs
Click "Edit Collection Content" and add files and/or URLs:
<img width="455" alt="image" src="https://github.com/user-attachments/assets/3c5f0c62-7e9a-4e0b-836a-d76ab59f6085" />

The page will refresh, verify it shows the correct URLs/files:
<img width="772" alt="image" src="https://github.com/user-attachments/assets/90c63ae5-0e46-4ffe-8e3b-ba92edf4facc" />

### Verify with assistant

Choose the corresponding Collection ID in an assistant:
<img width="546" alt="image" src="https://github.com/user-attachments/assets/06dde0b6-6473-4a7e-961c-8cd089eaaacf" />

Try to verify that the collections contains the correct content:
<img width="668" alt="image" src="https://github.com/user-attachments/assets/edd8f9b3-546e-4c4f-a7c4-4aace8148f61" />
