### PR TITLE
refactor chat input

### DIFF
--- a/frontend/src/lib/components/Chat/Chat.svelte
+++ b/frontend/src/lib/components/Chat/Chat.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import ChatInput from '$lib/components/Chat/ChatInput.svelte'
   import Icon from '$lib/components/Icon/Icon.svelte'
   import { icons } from '$lib/components/Icon/icons.js'
   import ChatMessage from '$lib/components/Chat/ChatMessage.svelte'
+  import ChatInput from '$lib/components/Chat/ChatInput.svelte'
 
   interface Message {
     timestamp: string
@@ -19,7 +19,10 @@
   const { messages, inputPlaceholder, onSubmitMessage }: Props = $props()
 
   let scrollContainer: HTMLDivElement = undefined as unknown as HTMLDivElement
+
   let isContentNearBottom = $state(false)
+  let chatInput = $state('')
+
   const contentIsScrollable = $derived(messages.length > 0 && scrollContainer && scrollContainer.scrollHeight > scrollContainer.clientHeight)
 
   function scrollToBottom() {
@@ -31,6 +34,13 @@
     isContentNearBottom =
       scrollContainer &&
       scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight <= margin
+  }
+
+  function onHandleSubmit() {
+    if (chatInput.trim()) {
+      onSubmitMessage(chatInput)
+      chatInput = ''
+    }
   }
 
   $effect(() => {
@@ -66,8 +76,10 @@
         <Icon icon={icons.scroll} />
       </button>
     </div>
-    <div class="relative rounded-2xl border bg-white p-2 z-10 w-[60rem] mx-auto">
-      <ChatInput send={onSubmitMessage} placeholder={inputPlaceholder} />
+    <div class="relative rounded-2xl border bg-white z-10 w-[60rem] mx-auto">
+      <ChatInput placeholder={inputPlaceholder} bind:value={chatInput} onSubmit={onHandleSubmit}>
+        <div></div>
+      </ChatInput>
     </div>
   </div>
 </div>

--- a/frontend/src/lib/components/Chat/ChatInput.stories.svelte
+++ b/frontend/src/lib/components/Chat/ChatInput.stories.svelte
@@ -1,25 +1,16 @@
-<script module>
-  import { defineMeta } from '@storybook/addon-svelte-csf';
-  import { action } from '@storybook/addon-actions';
-  import ChatInput from '$lib/components/Chat/ChatInput.svelte';
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf'
+  import ChatInput from './ChatInput.svelte'
 
   const { Story } = defineMeta({
     title: 'Components/Chat/ChatInput',
     component: ChatInput,
     tags: ['autodocs'],
-    argTypes: {
-      placeholder: {
-        control: 'text',
-        description: 'Placeholder text for the input field.',
-      },
-    },
-  });
+  })
 </script>
 
-<Story
-  name="Default"
-  args={{
-    placeholder: 'Type your message...',
-  }}
-  send={action('send')}
-></Story>
+<Story name="Default">
+  <ChatInput placeholder='' value='' onSubmit={() => {console.log('Send message!')}}>
+    <div></div>
+  </ChatInput>
+</Story>

--- a/frontend/src/lib/components/Chat/ChatInput.stories.svelte
+++ b/frontend/src/lib/components/Chat/ChatInput.stories.svelte
@@ -4,7 +4,6 @@
 
   const { Story } = defineMeta({
     title: 'Components/Chat/ChatInput',
-    component: ChatInput,
     tags: ['autodocs'],
   })
 </script>

--- a/frontend/src/lib/components/Chat/ChatInput.svelte
+++ b/frontend/src/lib/components/Chat/ChatInput.svelte
@@ -16,7 +16,15 @@
     const target = e.target as HTMLTextAreaElement
     target.style.height = 'auto'
     target.style.height = target.scrollHeight + 'px'
+
+    const maxHeight = parseInt(getComputedStyle(target).maxHeight)
+    if (target.scrollHeight >= maxHeight) {
+      target.style.overflowY = 'auto'
+    } else {
+      target.style.overflowY = 'hidden'
+    }
   }
+
 
   function resetTextareaHeight() {
     if (textareaElement) {

--- a/frontend/src/lib/components/Chat/ChatInput.svelte
+++ b/frontend/src/lib/components/Chat/ChatInput.svelte
@@ -1,42 +1,85 @@
 <script lang="ts">
-  export let placeholder: string = ''
-  export let send: (message: string) => void = () => {
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    placeholder: string
+    value: string
+    onSubmit: () => void
+    children: Snippet
   }
 
-  let message = ''
+  let { placeholder, value = $bindable(), onSubmit, children }: Props = $props()
 
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      const currentMessage = (e.target as HTMLInputElement).value
-      handleSend(currentMessage)
+  let textareaElement: HTMLTextAreaElement
+
+  function autoResize(e: Event) {
+    const target = e.target as HTMLTextAreaElement
+    target.style.height = 'auto'
+    target.style.height = target.scrollHeight + 'px'
+  }
+
+  function resetTextareaHeight() {
+    if (textareaElement) {
+      textareaElement.style.height = 'auto'
     }
   }
 
-  function handleSend(currentMessage: string) {
-    if (currentMessage.trim() === '') return
-    send(currentMessage)
-    message = ''
+  function handleDivClick(e: MouseEvent | TouchEvent) {
+    if (e.currentTarget === e.target) {
+      textareaElement.focus()
+    }
   }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      textareaElement.focus()
+      e.preventDefault()
+    }
+  }
+
+  function handleTextareaKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      onSubmit()
+    }
+  }
+
+  function handleSend() {
+    onSubmit()
+    textareaElement.focus()
+  }
+
+  $effect(() => {
+    if (value === '') {
+      resetTextareaHeight()
+    }
+  })
 </script>
 
-<div class="flex items-center gap-2">
-  <input
-    type="text"
-    class="flex-grow border-0 bg-white rounded-full px-4 py-2 text-gray-800 placeholder-gray-400 focus:outline-none"
-    placeholder={placeholder}
-    bind:value={message}
-    on:keydown={handleKeyDown}
-  />
-  <button
-    class="btn btn-square bg-orange-600 text-gray-50"
-    on:click={() => handleSend(message)}
-    aria-label="Send message"
+<div class="flex flex-col rounded-2xl p-3 gap-2 w-[60rem]">
+  <div>
+      <textarea
+        bind:this={textareaElement}
+        rows="1"
+        bind:value
+        {placeholder}
+        class="textarea w-full px-1 resize-none focus:outline-none border-none min-h-[20px] max-h-40 overflow-y-hidden"
+        oninput={autoResize}
+        onkeydown={handleTextareaKeyDown}
+      ></textarea>
+  </div>
+  <div
+    role="toolbar"
+    tabindex="0"
+    onclick={handleDivClick}
+    onkeydown={handleKeyDown}
+    class="flex flex-row items-center justify-between"
   >
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-         stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-up">
-      <path d="m5 12 7-7 7 7" />
-      <path d="M12 19V5" />
-    </svg>
-  </button>
+    <div class="flex-1">
+      {@render children()}
+    </div>
+    <div class="flex-shrink-0">
+      <button class="btn btn-sm" onclick={handleSend}>Send</button>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
New chat input component:
- The input field is converted from a input field to a text area.
- The text area is expandable to a max height, after which a scroll bar is used. This corresponds to similar user know interfaces.
- The new chat input accepts child components. These will be displayed in the bottom row of the chat input. Ex. of a child component would be toggle button for web search.

New UI:
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/f5b3c7ac-9fe3-40d5-bb65-ca8b93cf39b5" />

Old UI for comparison:
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/8a757776-189e-4f3d-b2d5-40a81f2c07b8" />
