### PR TITLE
Avatar support

### DIFF
--- a/backend/src/modules/assistants/MongoAssistantService.py
+++ b/backend/src/modules/assistants/MongoAssistantService.py
@@ -1,5 +1,7 @@
+import base64
 from typing import Mapping, Any
 
+import gridfs
 from bson import ObjectId
 from pymongo.asynchronous.database import AsyncDatabase
 
@@ -21,7 +23,8 @@ class MongoAssistantService(IAssistantService):
         assistant = Assistant(
             id=str(ObjectId()),
             owner=as_uid,
-            meta=AssistantMeta(name='', description='', sample_questions=[], allow_files=False, is_public=False),
+            meta=AssistantMeta(name='', description='', avatar_base64='', sample_questions=[], allow_files=False,
+                               is_public=False),
             model='',
             llm_api_key=None,
             instructions='',
@@ -91,7 +94,7 @@ class MongoAssistantService(IAssistantService):
         if doc is None:
             return None
 
-        return self._doc_to_assistant(doc, redact_key=redact_key)
+        return await self._doc_to_assistant(doc, redact_key=redact_key)
 
     async def get_owned_assistants(self, as_uid: str) -> list[Assistant]:
         cursor = self._database['assistants'].find(
@@ -110,7 +113,7 @@ class MongoAssistantService(IAssistantService):
                 'extra_llm_params',
             ]
         )
-        return [self._doc_to_assistant(doc, True) async for doc in cursor]
+        return [await self._doc_to_assistant(doc, True) async for doc in cursor]
 
     async def get_assistant_info(self, as_uid: str, assistant_id: str) -> AssistantInfo | None:
         can_access = await self._resource_service.can_access(as_uid=as_uid, resource=assistant_id)
@@ -134,7 +137,7 @@ class MongoAssistantService(IAssistantService):
         if doc is None:
             return None
 
-        return self._doc_to_assistant_info(doc)
+        return await self._doc_to_assistant_info(doc)
 
     async def get_available_assistants(self, as_uid: str) -> list[AssistantInfo]:
         resources = await self._resource_service.get_resources(as_uid=as_uid)
@@ -145,7 +148,7 @@ class MongoAssistantService(IAssistantService):
                 {'meta.is_public': True}
             ]}
         )
-        return [self._doc_to_assistant_info(doc) async for doc in cursor]
+        return [await self._doc_to_assistant_info(doc) async for doc in cursor]
 
     async def update_assistant(
             self,
@@ -153,6 +156,7 @@ class MongoAssistantService(IAssistantService):
             assistant_id: str,
             name: str | None = None,
             description: str | None = None,
+            avatar_base64: str | None = None,
             allow_files: bool | None = None,
             sample_questions: list[str] | None = None,
             is_public: bool | None = None,
@@ -185,14 +189,37 @@ class MongoAssistantService(IAssistantService):
             }
         )
 
+        if avatar_base64 is not None:
+            fs = gridfs.AsyncGridFS(self._database)
+
+            doc = await self._database['assistants'].find_one({'_id': ObjectId(assistant_id), 'owner': as_uid},
+                                                              projection=['meta'])
+
+            if doc and 'gfs_avatar' in doc['meta'] and doc['meta']['gfs_avatar'] is not None:
+                await fs.delete(doc['meta']['gfs_avatar'])
+
+            decoded = base64.b64decode(avatar_base64)
+            new_id = await fs.put(decoded, filename=f'{assistant_id}.png')
+
+            await self._database['assistants'].update_one({'_id': ObjectId(assistant_id), 'owner': as_uid},
+                                                          {'$set': {'meta.gfs_avatar': new_id}})
+
         return result.matched_count == 1
 
     async def delete_assistant(self, as_uid: str, assistant_id: str) -> None:
         if is_valid_mongo_id(assistant_id):
             await self._database['assistants'].delete_one({'_id': ObjectId(assistant_id), 'owner': as_uid})
 
-    @staticmethod
-    def _doc_to_assistant(doc: Mapping[str, Any], redact_key: bool) -> Assistant:
+    async def _get_avatar_base64(self, file_id: ObjectId | None) -> str | None:
+        if file_id is None:
+            return None
+        fs = gridfs.AsyncGridFS(self._database)
+        file = await fs.get(file_id)
+        if file is None:
+            return None
+        return base64.b64encode(await file.read()).decode('utf-8')
+
+    async def _doc_to_assistant(self, doc: Mapping[str, Any], redact_key: bool) -> Assistant:
         api_key = (MongoAssistantService._redact_key(doc['llm_api_key']) if redact_key else doc[
             'llm_api_key']) if 'llm_api_key' in doc else None
         return Assistant(
@@ -201,6 +228,8 @@ class MongoAssistantService(IAssistantService):
             meta=AssistantMeta(
                 name=doc['meta']['name'],
                 description=doc['meta']['description'],
+                avatar_base64=await self._get_avatar_base64(doc['meta']['gfs_avatar']) if 'gfs_avatar' in doc[
+                    'meta'] else None,
                 allow_files=doc['meta']['allow_files'],
                 sample_questions=doc['meta']['sample_questions'],
                 is_public=doc['meta']['is_public'] if 'is_public' in doc['meta'] else False,
@@ -212,12 +241,13 @@ class MongoAssistantService(IAssistantService):
             extra_llm_params=doc['extra_llm_params'] if 'extra_llm_params' in doc else None,
         )
 
-    @staticmethod
-    def _doc_to_assistant_info(doc: Mapping[str, Any]) -> AssistantInfo:
+    async def _doc_to_assistant_info(self, doc: Mapping[str, Any]) -> AssistantInfo:
         return AssistantInfo(
             id=str(doc['_id']),
             name=doc['meta']['name'],
             description=doc['meta']['description'],
+            avatar_base64=await self._get_avatar_base64(doc['meta']['gfs_avatar']) if 'gfs_avatar' in doc[
+                'meta'] else None,
             sample_questions=doc['meta']['sample_questions'],
             model=doc['model'],
         )

--- a/backend/src/modules/assistants/models/AssistantInfo.py
+++ b/backend/src/modules/assistants/models/AssistantInfo.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class AssistantInfo(BaseModel):
+    id: str
+    name: str
+    description: str
+    sample_questions: list[str]
+    model: str

--- a/backend/src/modules/assistants/models/AssistantInfo.py
+++ b/backend/src/modules/assistants/models/AssistantInfo.py
@@ -5,5 +5,6 @@ class AssistantInfo(BaseModel):
     id: str
     name: str
     description: str
+    avatar_base64: str | None
     sample_questions: list[str]
     model: str

--- a/backend/src/modules/assistants/models/AssistantMeta.py
+++ b/backend/src/modules/assistants/models/AssistantMeta.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 class AssistantMeta(BaseModel):
     name: str
     description: str
+    avatar_base64: str | None
     allow_files: bool
     sample_questions: list[str]
     is_public: bool

--- a/backend/src/modules/assistants/protocols/IAssistantService.py
+++ b/backend/src/modules/assistants/protocols/IAssistantService.py
@@ -1,6 +1,7 @@
 from typing import Protocol
 
 from src.modules.assistants.models.Assistant import Assistant
+from src.modules.assistants.models.AssistantInfo import AssistantInfo
 from src.modules.assistants.models.Model import Model
 
 
@@ -20,7 +21,10 @@ class IAssistantService(Protocol):
     async def get_owned_assistants(self, as_uid: str) -> list[Assistant]:
         ...
 
-    async def get_available_assistants(self, as_uid: str) -> list[Assistant]:
+    async def get_assistant_info(self, as_uid: str, assistant_id: str) -> AssistantInfo | None:
+        ...
+
+    async def get_available_assistants(self, as_uid: str) -> list[AssistantInfo]:
         ...
 
     async def update_assistant(

--- a/backend/src/modules/assistants/protocols/IAssistantService.py
+++ b/backend/src/modules/assistants/protocols/IAssistantService.py
@@ -33,6 +33,7 @@ class IAssistantService(Protocol):
             assistant_id: str,
             name: str | None = None,
             description: str | None = None,
+            avatar_base64: str | None = None,
             allow_files: bool | None = None,
             sample_questions: list[str] | None = None,
             is_public: bool | None = None,

--- a/backend/src/modules/assistants/test_assistant_service.py
+++ b/backend/src/modules/assistants/test_assistant_service.py
@@ -160,6 +160,55 @@ class BaseAssistantServiceTestClass:
     @staticmethod
     @pytest.mark.asyncio
     @pytest.mark.mongo
+    async def test_get_assistant_info(service: IAssistantService):
+        aid = await service.create_assistant(as_uid='john')
+        await service.update_assistant(
+            as_uid='john',
+            assistant_id=aid,
+            name='cool name',
+            description='cool desc',
+            sample_questions=['a', 'b', 'c'],
+            model='fai:my_model',
+        )
+
+        result = await service.get_assistant_info(as_uid='john', assistant_id=aid)
+
+        assert result.id == aid
+        assert result.name == 'cool name'
+        assert result.description == 'cool desc'
+        assert result.sample_questions == ['a', 'b', 'c']
+        assert result.model == 'fai:my_model'
+
+    @staticmethod
+    @pytest.mark.asyncio
+    @pytest.mark.mongo
+    async def test_get_assistant_info_public(service: IAssistantService):
+        aid = await service.create_assistant(as_uid='john')
+        await service.update_assistant(
+            as_uid='john',
+            assistant_id=aid,
+            name='cool name',
+            description='cool desc',
+            sample_questions=['a', 'b', 'c'],
+            model='fai:my_model',
+            is_public=True
+        )
+        private_aid = await service.create_assistant(as_uid='john')
+
+        result1 = await service.get_assistant_info(as_uid='jane', assistant_id=aid)
+        result2 = await service.get_assistant_info(as_uid='jane', assistant_id=private_aid)
+
+        assert result1.id == aid
+        assert result1.name == 'cool name'
+        assert result1.description == 'cool desc'
+        assert result1.sample_questions == ['a', 'b', 'c']
+        assert result1.model == 'fai:my_model'
+
+        assert result2 is None
+
+    @staticmethod
+    @pytest.mark.asyncio
+    @pytest.mark.mongo
     async def test_get_available_assistants(service: IAssistantService, group_service: IGroupService):
         john_private_aid = await service.create_assistant(as_uid='john')
         shared_aid = await service.create_assistant(as_uid='john')
@@ -170,10 +219,30 @@ class BaseAssistantServiceTestClass:
 
         assert len(result) == 2
         assert jane_private_aid in [a.id for a in result]
-        assert next(a for a in result if a.id == jane_private_aid).owner == 'jane'
         assert shared_aid in [a.id for a in result]
-        assert next(a for a in result if a.id == shared_aid).owner == 'john'
         assert john_private_aid not in [a.id for a in result]
+
+    @staticmethod
+    @pytest.mark.asyncio
+    @pytest.mark.mongo
+    async def test_get_available_assistants_completeness(service: IAssistantService):
+        aid = await service.create_assistant(as_uid='john')
+        await service.update_assistant(
+            as_uid='john',
+            assistant_id=aid,
+            name='cool name',
+            description='cool desc',
+            sample_questions=['a', 'b', 'c'],
+            model='fai:my_model',
+        )
+
+        result = await service.get_available_assistants(as_uid='john')
+
+        assert result[0].id == aid
+        assert result[0].name == 'cool name'
+        assert result[0].description == 'cool desc'
+        assert result[0].sample_questions == ['a', 'b', 'c']
+        assert result[0].model == 'fai:my_model'
 
     @staticmethod
     @pytest.mark.asyncio

--- a/backend/src/modules/assistants/test_assistant_service.py
+++ b/backend/src/modules/assistants/test_assistant_service.py
@@ -167,6 +167,7 @@ class BaseAssistantServiceTestClass:
             assistant_id=aid,
             name='cool name',
             description='cool desc',
+            avatar_base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
             sample_questions=['a', 'b', 'c'],
             model='fai:my_model',
         )
@@ -176,6 +177,7 @@ class BaseAssistantServiceTestClass:
         assert result.id == aid
         assert result.name == 'cool name'
         assert result.description == 'cool desc'
+        assert result.avatar_base64 == 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='
         assert result.sample_questions == ['a', 'b', 'c']
         assert result.model == 'fai:my_model'
 
@@ -189,6 +191,7 @@ class BaseAssistantServiceTestClass:
             assistant_id=aid,
             name='cool name',
             description='cool desc',
+            avatar_base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
             sample_questions=['a', 'b', 'c'],
             model='fai:my_model',
             is_public=True
@@ -201,6 +204,7 @@ class BaseAssistantServiceTestClass:
         assert result1.id == aid
         assert result1.name == 'cool name'
         assert result1.description == 'cool desc'
+        assert result1.avatar_base64 == 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='
         assert result1.sample_questions == ['a', 'b', 'c']
         assert result1.model == 'fai:my_model'
 
@@ -232,6 +236,7 @@ class BaseAssistantServiceTestClass:
             assistant_id=aid,
             name='cool name',
             description='cool desc',
+            avatar_base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
             sample_questions=['a', 'b', 'c'],
             model='fai:my_model',
         )
@@ -241,6 +246,8 @@ class BaseAssistantServiceTestClass:
         assert result[0].id == aid
         assert result[0].name == 'cool name'
         assert result[0].description == 'cool desc'
+        assert result[
+                   0].avatar_base64 == 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='
         assert result[0].sample_questions == ['a', 'b', 'c']
         assert result[0].model == 'fai:my_model'
 
@@ -320,6 +327,7 @@ class BaseAssistantServiceTestClass:
             assistant_id=aid,
             name='a',
             description='b',
+            avatar_base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
             allow_files=True,
             sample_questions=['c', 'd', 'e'],
             is_public=True,
@@ -342,6 +350,7 @@ class BaseAssistantServiceTestClass:
         assert result.owner == 'john'
         assert result.meta.name == 'a'
         assert result.meta.description == 'b'
+        assert result.meta.avatar_base64 == 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='
         assert result.meta.allow_files is True
         assert result.meta.sample_questions == ['c', 'd', 'e']
         assert result.meta.is_public is True

--- a/frontend/src/lib/components/assistant/AssistantTable.svelte
+++ b/frontend/src/lib/components/assistant/AssistantTable.svelte
@@ -28,6 +28,10 @@
       >
         <td>
           <div class="flex flex-col">
+            {#if assistant.avatar_base64}
+              <img src={`data:image/png;base64,${assistant.avatar_base64}`} alt="avatar"
+                   class="w-10 h-10 bg-white object-contain p-2" />
+            {/if}
             <div class="text-base">{assistant.name ? assistant.name : 'Untitled assistant'}</div>
             <div class="text-xs opacity-50">{assistant.id}</div>
           </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -65,6 +65,7 @@ export interface IAssistant {
   id: string
   name: string
   description: string
+  avatar_base64: string
   instructions: string
   model: string
   collection?: ICollection


### PR DESCRIPTION
Added support for uploading and fetching avatar images per assistant. Only PNG supported atm, max file size 1 MB.

To facilitate, added new endpoint `GET /{assistant_id}/info` to fetch information intended for displaying and selecting an assistant as opposed to administrating. Existing assistant endpoints are unchanged but in the future the `GET /{assistant_id}` will be changed to only be accessible by the owner.