### PR TITLE
feat(frontend/chat): add abort and status for idle chat

### DIFF
--- a/frontend/src/lib/chat/chat.ts
+++ b/frontend/src/lib/chat/chat.ts
@@ -3,6 +3,10 @@ export interface RealtimeChatMessage {
   message: string,
 }
 
+export interface ChatController {
+  close: () => void,
+}
+
 export async function sendChatMessage(
   message: string,
   assistantId: string | undefined,
@@ -10,7 +14,7 @@ export async function sendChatMessage(
   onAddMessage: (message: RealtimeChatMessage) => void,
   onUpdateLastMessage: (message: RealtimeChatMessage) => void,
   onGoto: (url: string) => void,
-  onError: (error: string) => void) {
+  onError: (error: string) => void): Promise<ChatController | null> {
 
   onAddMessage({ source: 'user', message: message })
   onAddMessage({ source: 'assistant', message: '...' })
@@ -24,7 +28,7 @@ export async function sendChatMessage(
   if (!storeMessageResponse.ok) {
     console.error('Error storing message', storeMessageResponse)
     onError(`Error storing message (${storeMessageResponse.status}). Try again or contact support.`)
-    return
+    return null
   }
 
   const { messageId } = await storeMessageResponse.json()
@@ -62,4 +66,11 @@ export async function sendChatMessage(
     console.log('es message end', e)
     es.close()
   })
+
+  return {
+    close: () => {
+      console.log('es closing chat connection')
+      es.close()
+    }
+  }
 }

--- a/frontend/src/lib/components/Chat/Chat.svelte
+++ b/frontend/src/lib/components/Chat/Chat.svelte
@@ -20,9 +20,11 @@
     messages: Message[],
     inputPlaceholder: string,
     onSubmitMessage: (message: string) => void
+    chatStateIdle: boolean,
+    onStopChat: () => void,
   }
 
-  let { assistants, selectedAssistantId = $bindable(), messages, inputPlaceholder, onSubmitMessage }: Props = $props()
+  let { assistants, selectedAssistantId = $bindable(), messages, inputPlaceholder, onSubmitMessage, chatStateIdle, onStopChat }: Props = $props()
 
   let scrollContainer: HTMLDivElement = undefined as unknown as HTMLDivElement
 
@@ -89,6 +91,8 @@
         bind:value={chatInput}
         onSubmit={onHandleSubmit}
         disabled={selectedAssistantId === ''}
+        receivingMessage={!chatStateIdle}
+        {onStopChat}
       >
         <ActionButtons {assistants} bind:selectedAssistantId {disableAssistantPicker} />
       </ChatInput>

--- a/frontend/src/lib/components/Chat/ChatInput.svelte
+++ b/frontend/src/lib/components/Chat/ChatInput.svelte
@@ -7,9 +7,11 @@
     onSubmit: () => void
     children: Snippet
     disabled: boolean
+    receivingMessage: boolean
+    onStopChat: () => void
   }
 
-  let { placeholder, value = $bindable(), onSubmit, children, disabled }: Props = $props()
+  let { placeholder, value = $bindable(), onSubmit, children, disabled, receivingMessage, onStopChat }: Props = $props()
 
   let disableSend = $derived.by(() => {
     return disabled || value === ''
@@ -96,9 +98,13 @@
       {@render children()}
     </div>
     <div class="flex-shrink-0">
-      <div class={disableSend ? "tooltip" : ""} data-tip={value === '' ? 'Message is empty' : 'Select assistant'}>
-        <button class="btn btn-sm" onclick={handleSend} disabled={disableSend}>Send</button>
-      </div>
+      {#if !receivingMessage}
+        <div class={disableSend ? "tooltip" : ""} data-tip={value === '' ? 'Message is empty' : 'Select assistant'}>
+          <button class="btn btn-sm" onclick={handleSend} disabled={disableSend}>Send</button>
+        </div>
+      {:else }
+        <button class="btn btn-sm" onclick={onStopChat}>Abort</button>
+      {/if}
     </div>
   </div>
 </div>

--- a/frontend/src/lib/layouts/ChatLayout.svelte
+++ b/frontend/src/lib/layouts/ChatLayout.svelte
@@ -22,6 +22,8 @@
     conversationId: string
     onDeleteConversation: (id: string) => void
     onStartNewChat: () => void
+    chatStateIdle: boolean
+    onStopChat: () => void
   }
 
   let {
@@ -35,6 +37,8 @@
     conversationId,
     onDeleteConversation,
     onStartNewChat,
+    chatStateIdle,
+    onStopChat,
   }: Props = $props()
 </script>
 
@@ -71,6 +75,8 @@
         messages={messages}
         inputPlaceholder={inputPlaceholder}
         {onSubmitMessage}
+        {chatStateIdle}
+        {onStopChat}
       />
     </main>
   </div>


### PR DESCRIPTION
Implementation needs more work: `chat.ts` needs a refactor that will come in a future PR.
Main concern of this PR is to add abort button to chat and prevent synchronize chat events (allow chat send request only if the chat is idle).