### PR TITLE
✨ Feat(backend/assistant): add max_collection_results

### DIFF
--- a/backend/src/api/assistant.py
+++ b/backend/src/api/assistant.py
@@ -196,6 +196,7 @@ class GetAssistantResponseAssistant(BaseModel):
     llm_api_key: str | None
     instructions: str
     collection_id: str | None
+    max_collection_results: int
     extra_llm_params: dict[str, float | int | bool | str]
 
 
@@ -232,6 +233,7 @@ async def get_assistant(assistant_id: str, services: ServicesDependency, auth_id
             llm_api_key=result.llm_api_key,
             instructions=result.instructions,
             collection_id=result.collection_id,
+            max_collection_results=result.max_collection_results,
             extra_llm_params=result.extra_llm_params if result.extra_llm_params else {}
         )
     )
@@ -280,6 +282,7 @@ class UpdateAssistantRequest(BaseModel):
     llm_api_key: str | None = None
     instructions: str | None = None
     collection_id: str | None = None
+    max_collection_results: int | None = None
     extra_llm_params: dict[str, float | int | bool | str] | None = None
 
 
@@ -308,6 +311,7 @@ async def update_assistant(
         llm_api_key=body.llm_api_key,
         instructions=body.instructions,
         collection_id=body.collection_id,
+        max_collection_results=body.max_collection_results,
         extra_llm_params=body.extra_llm_params,
     )
 

--- a/backend/src/modules/assistants/MongoAssistantService.py
+++ b/backend/src/modules/assistants/MongoAssistantService.py
@@ -32,6 +32,7 @@ class MongoAssistantService(IAssistantService):
             llm_api_key=None,
             instructions='',
             collection_id=None,
+            max_collection_results=10,
             extra_llm_params=None
         )
         result = await self._database['assistants'].insert_one({
@@ -91,6 +92,7 @@ class MongoAssistantService(IAssistantService):
                 'max_tokens',
                 'allow_files',
                 'collection_id',
+                'max_collection_results',
                 'extra_llm_params',
                 'response_schema'
             ]
@@ -114,6 +116,7 @@ class MongoAssistantService(IAssistantService):
                 'max_tokens',
                 'allow_files',
                 'collection_id',
+                'max_collection_results',
                 'extra_llm_params',
                 'response_schema'
             ]
@@ -171,6 +174,7 @@ class MongoAssistantService(IAssistantService):
             llm_api_key: str | None = None,
             instructions: str | None = None,
             collection_id: str | None = None,
+            max_collection_results: int | None = None,
             response_schema: dict[str, object] | None = None,
             extra_llm_params: dict[str, float | int | bool | str] | None = None
     ) -> bool:
@@ -190,6 +194,7 @@ class MongoAssistantService(IAssistantService):
         self._add_to_dict_unless_none(update_dict, 'instructions', instructions)
         self._add_to_dict_unless_none(update_dict, 'extra_llm_params', extra_llm_params)
         self._add_to_dict_unless_none(update_dict, 'collection_id', collection_id)
+        self._add_to_dict_unless_none(update_dict, 'max_collection_results', max_collection_results)
         self._add_to_dict_unless_none(update_dict, 'response_schema', response_schema)
 
         result = await self._database['assistants'].update_one(
@@ -299,8 +304,8 @@ class MongoAssistantService(IAssistantService):
                 description=doc['meta']['description'],
                 avatar_base64=await self._get_avatar_base64(doc['meta']['gfs_avatar']) if 'gfs_avatar' in doc[
                     'meta'] else None,
-                allow_files=doc['meta']['allow_files'],
-                sample_questions=doc['meta']['sample_questions'],
+                allow_files=doc['meta']['allow_files'] if 'allow_files' in doc['meta'] else False,
+                sample_questions=doc['meta']['sample_questions'] if 'sample_questions' in doc['meta'] else [],
                 is_public=doc['meta']['is_public'] if 'is_public' in doc['meta'] else False,
                 primary_color=doc['meta']['primary_color'] if 'primary_color' in doc['meta'] else '#ffffff'
             ),
@@ -308,6 +313,7 @@ class MongoAssistantService(IAssistantService):
             llm_api_key=api_key,
             instructions=doc['instructions'],
             collection_id=doc['collection_id'],
+            max_collection_results=doc['max_collection_results'] if 'max_collection_results' in doc else 10,
             extra_llm_params=doc['extra_llm_params'] if 'extra_llm_params' in doc else None,
             response_schema=doc['response_schema'] if 'response_schema' in doc else None
         )
@@ -319,7 +325,7 @@ class MongoAssistantService(IAssistantService):
             description=doc['meta']['description'],
             avatar_base64=await self._get_avatar_base64(doc['meta']['gfs_avatar']) if 'gfs_avatar' in doc[
                 'meta'] else None,
-            sample_questions=doc['meta']['sample_questions'],
+            sample_questions=doc['meta']['sample_questions'] if 'sample_questions' in doc['meta'] else [],
             model=doc['model'],
             primary_color=doc['meta']['primary_color'] if 'primary_color' in doc['meta'] else '#ffffff'
         )

--- a/backend/src/modules/assistants/models/Assistant.py
+++ b/backend/src/modules/assistants/models/Assistant.py
@@ -11,5 +11,6 @@ class Assistant(BaseModel):
     llm_api_key: str | None
     instructions: str
     collection_id: str | None
+    max_collection_results: int
     response_schema: dict[str, object] | None = None
     extra_llm_params: dict[str, float | int | bool | str] | None

--- a/backend/src/modules/assistants/protocols/IAssistantService.py
+++ b/backend/src/modules/assistants/protocols/IAssistantService.py
@@ -42,6 +42,7 @@ class IAssistantService(Protocol):
             llm_api_key: str | None = None,
             instructions: str | None = None,
             collection_id: str | None = None,
+            max_collection_results: int | None = None,
             response_schema: dict[str, object] | None = None,
             extra_llm_params: dict[str, float | int | bool | str] | None = None
     ) -> bool:

--- a/backend/src/modules/assistants/test_assistant_service.py
+++ b/backend/src/modules/assistants/test_assistant_service.py
@@ -443,6 +443,7 @@ class BaseAssistantServiceTestClass:
             llm_api_key='g',
             instructions='h',
             collection_id='i',
+            max_collection_results=5,
             response_schema={"name": "my_schema",
                              "schema": {"type": "object", "properties": {"foo": {"type": "number"}}}},
             extra_llm_params={
@@ -474,6 +475,7 @@ class BaseAssistantServiceTestClass:
         assert result.extra_llm_params['some_bool'] is True
         assert result.extra_llm_params['some_str'] == 'j'
         assert result.collection_id == 'i'
+        assert result.max_collection_results == 5
 
     @staticmethod
     @pytest.mark.asyncio

--- a/backend/src/modules/chat/LLMChatService.py
+++ b/backend/src/modules/chat/LLMChatService.py
@@ -92,7 +92,7 @@ class LLMChatService(IChatService):
             rag_llm_service: ILLMService = self._llm_factory.get(model_key=rag_scoring_assistant.model)
 
             rag_results = await self._collection_service.query_collection(assistant.collection_id, message,
-                                                                          max_results=10)
+                                                                          max_results=assistant.max_collection_results)
 
             formatted_results = [f"(source:{r.source}, page: {r.page_number})\n{r.content}" for r in rag_results]
 


### PR DESCRIPTION
Add max_collection_results to fine tune amount of RAG query results per assistant (defaults to 10). Set breakpoint in LLMChatService.py @ line ~97 to inspect and verify, or try setting it to 1 and see that a assistant will now struggle to answer correctly. High numbers (>10) *may* increase accuracy but also takes longer to process and consumes more tokens for scoring.