### PR TITLE
✨ Feat(backend/llm): enable web search

### DIFF
--- a/backend/src/modules/chat/protocols/IChatService.py
+++ b/backend/src/modules/chat/protocols/IChatService.py
@@ -1,11 +1,16 @@
 from typing import Protocol, AsyncGenerator
 
 from src.modules.chat.models.ChatEvent import ChatEvent
+from src.modules.llm.models.Feature import Feature
 
 
 class IChatService(Protocol):
-    def start_new_chat(self, as_uid: str, assistant_id: str, message: str) -> AsyncGenerator[ChatEvent, None]:
+    def start_new_chat(self, as_uid: str, assistant_id: str, message: str, enabled_features: list[Feature]) -> \
+    AsyncGenerator[
+        ChatEvent, None]:
         ...
 
-    def continue_chat(self, as_uid: str, conversation_id: str, message: str) -> AsyncGenerator[ChatEvent, None]:
+    def continue_chat(self, as_uid: str, conversation_id: str, message: str, enabled_features: list[Feature]) -> \
+    AsyncGenerator[
+        ChatEvent, None]:
         ...

--- a/backend/src/modules/llm/models/Feature.py
+++ b/backend/src/modules/llm/models/Feature.py
@@ -1,0 +1,9 @@
+from enum import Enum, auto
+
+
+class Feature(Enum):
+    # noinspection PyMethodParameters
+    def _generate_next_value_(name: str, start: int, count: int, last_values: list) -> str:
+        return name.lower()
+
+    WEB_SEARCH = auto()

--- a/backend/src/modules/llm/protocols/ILLMService.py
+++ b/backend/src/modules/llm/protocols/ILLMService.py
@@ -2,16 +2,17 @@ from collections.abc import AsyncGenerator
 from typing import Protocol
 
 from src.modules.llm.models.Delta import Delta
+from src.modules.llm.models.Feature import Feature
 from src.modules.llm.models.Message import Message
 
 
 class ILLMService(Protocol):
-    def stream_llm(
+    def run(
             self,
             model: str,
             api_key: str,
             messages: list[Message],
-            response_schema: dict[str, object] | None = None,
+            enabled_features: list[Feature],
             extra_params: dict[str, float | int | bool | str] | None = None
     ) -> AsyncGenerator[Delta, None]:
         ...


### PR DESCRIPTION
Enable basic web search for supported models by passing `"with_web_search": true` (`with_web_search=true` for SSE url param) to chat endpoints.

There is a bunch of cleanup that should be/is done but is not included in this PR to keep it simple.