### PR TITLE
fix(api): remove trailing slash from model endpoints to avoid redirect issues

### DIFF
--- a/backend/src/api/model.py
+++ b/backend/src/api/model.py
@@ -38,7 +38,7 @@ class CreateModelRequest(BaseModel):
 
 
 @auth.post(
-    '/',
+    '',
     ['model.write'],
     summary='Create Model',
     description='Create a new AI model for use with assistants.',
@@ -94,7 +94,7 @@ class GetModelsResponse(BaseModel):
 
 
 @auth.get(
-    '/',
+    '',
     ['model.read'],
     summary='List All Models',
     description='Get a list of all models (including disabled/deprecated for admins).',


### PR DESCRIPTION
- Changed model router GET and POST endpoints from '/' to '' (empty string)
- This follows the pattern used by other endpoints (settings, etc.)
- Fixes 307 redirect issue that was causing auth headers to be lost on pre-release server